### PR TITLE
feature: Unify all classifier models to inherit from abstract base model

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -4,7 +4,13 @@ from schemas.responses import MoralOutrage
 
 class BaseModel(ABC):
 
+    @staticmethod
+    def _validate_input(texts: list[str]) -> None:
+        if not isinstance(texts, list):
+            raise ValueError("Input must be a list of strings.")
+        if not all(isinstance(text, str) for text in texts):
+            raise ValueError("All items in the input list must be strings.")
+
     @abstractmethod
     def batch_classify(self, texts: list[str]) -> list[MoralOutrage | None]:
-        if not isinstance(texts, list) or not all(isinstance(text, str) for text in texts):
-            raise ValueError("Input must be a list of strings.")
+        pass

--- a/models/perspective_api/model.py
+++ b/models/perspective_api/model.py
@@ -25,7 +25,7 @@ class PerspectiveAPIModel(BaseModel):
             )
 
     def batch_classify(self, texts: list[str]) -> list[MoralOutrage]:
-        super().batch_classify(texts)  # Validate input
+        self._validate_input(texts)
 
         analyze_requests = [
             {


### PR DESCRIPTION
**Overview/Problem**:
All moral outrage classifiers models will have the batch_classify() method. We need a way to enforce this and add a degree of consistency to our interface.

**Solution**:
Create an abstract base class that defines the BaseModel, and have all other models inherit from it.

**Changes**:
- Defined the BaseModel in `models/perspective_api/model.py`.
- Added input checking in the BaseModel that the other models can inherit from for batch_classify() method. 
- Modified `models/perspective_api/model.py` to inherit from BaseModel, and call BaseModel's batch_classify() for input checking.

**State (After)**:
The same as before.

**Manual Verification**:
```
PYTHONPATH=. uv run models/perspective_api/examples_test.py
```

Change line 83 in `lib/testing_utils.py` to counts = [1, 10, 100] to speed up verification. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a shared model foundation to standardize batch classification behavior across implementations.
* **Bug Fixes**
  * Added pre-checks to validate batch text inputs, preventing invalid data from proceeding and reducing runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->