### PR TITLE
Update OpenAI defaults to gpt-5.4

### DIFF
--- a/docs/runbooks/HOW_TO_RUN_EVALS.md
+++ b/docs/runbooks/HOW_TO_RUN_EVALS.md
@@ -36,7 +36,7 @@ You can pass multiple family aliases, for example `--models openai --models pers
 
 ## Models currently supported
 
-Aliases are defined in `MODEL_REGISTRY` in `evaluation/model_registry.py`: `perspective_api`, `openai`, `qwen`, `anthropic`, and `minimax`. The merged `output.csv` records the **resolved** model id for LLM runs (for example `gpt-5-nano`), not the CLI alias. Run `metadata.json` lists both `llm_provider_name` and `resolved_model_id` per model, plus prompt fields for LLM facades.
+Aliases are defined in `MODEL_REGISTRY` in `evaluation/model_registry.py`: `perspective_api`, `openai`, `qwen`, `anthropic`, and `minimax`. The merged `output.csv` records the **resolved** model id for LLM runs (for example `gpt-5.4` for the `openai` alias), not the CLI alias. Run `metadata.json` lists both `llm_provider_name` and `resolved_model_id` per model, plus prompt fields for LLM facades.
 
 ## Pull Request Link
 

--- a/evaluation/smoke_tests/model_specific/openai.py
+++ b/evaluation/smoke_tests/model_specific/openai.py
@@ -1,4 +1,4 @@
-"""Smoke entrypoint: evaluation harness with OpenAI alias (resolved: gpt-5-nano).
+"""Smoke entrypoint: evaluation harness with OpenAI alias (resolved: gpt-5.4).
 
 To run:
 ```bash

--- a/models/llm/config/model_registry.py
+++ b/models/llm/config/model_registry.py
@@ -250,7 +250,7 @@ class ModelConfigRegistry:
         """Get the default model from the configuration.
 
         Returns:
-            Default model identifier (e.g., 'gpt-4o-mini')
+            Default model identifier (e.g., 'gpt-5.4')
 
         Raises:
             KeyError: If default_model is not found in the default configuration

--- a/models/llm/config/models.yaml
+++ b/models/llm/config/models.yaml
@@ -9,8 +9,8 @@
 
 models:
   default:
-    # our default model is gpt-4o-mini.
-    default_model: "gpt-4o-mini"
+    # our default model is gpt-5.4.
+    default_model: "gpt-5.4"
     llm_inference_kwargs:
       temperature: 0.0
 
@@ -18,6 +18,15 @@ models:
     llm_inference_kwargs:
       temperature: 0.0
     supported_models:
+      "gpt-5.4":
+        llm_inference_kwargs: {
+          # gpt-5 family: LiteLLM rejects temperature=0.0; use 1 (same as gpt-5-nano).
+          temperature: 1
+        }
+      "gpt-5.4-nano":
+        llm_inference_kwargs: {
+          temperature: 1
+        }
       "gpt-4o-mini":
         llm_inference_kwargs: {}
       "gpt-4o-mini-2024-07-18":

--- a/models/llm/llm_service.py
+++ b/models/llm/llm_service.py
@@ -48,7 +48,7 @@ class LLMService:
         """Get the provider instance for a given model.
 
         Args:
-            model: Model identifier (e.g., 'gpt-4o-mini', 'groq/llama3-8b-8192')
+            model: Model identifier (e.g., 'gpt-5.4', 'groq/llama3-8b-8192')
 
         Returns:
             Provider instance that supports the given model
@@ -324,7 +324,7 @@ class LLMService:
         Args:
             messages: List of message dicts with 'role' and 'content' keys
             response_model: Pydantic model class to parse the response into
-            model: Model to use (default: from config, falls back to gpt-4o-mini-2024-07-18)
+            model: Model to use (default: ``ModelConfigRegistry.get_default_model()`` from models.yaml)
             **kwargs: Additional parameters to pass to the API (temperature, max_tokens, etc.)
                 These override any default kwargs from the model configuration.
 
@@ -423,7 +423,7 @@ class LLMService:
         Args:
             prompts: List of prompt strings
             response_model: Pydantic model class to parse each response into
-            model: Model to use (default: from config, falls back to gpt-4o-mini-2024-07-18)
+            model: Model to use (default: ``ModelConfigRegistry.get_default_model()`` from models.yaml)
             role: Message role for all prompts (default: 'user')
             **kwargs: Additional parameters to pass to the API (temperature, max_tokens, etc.)
                 These override any default kwargs from the model configuration.

--- a/models/llm/models.py
+++ b/models/llm/models.py
@@ -14,7 +14,7 @@ class BaseHarnessLLMModel(ClassifierBaseModel):
     """Shared facade for all LLM models."""
 
     alias: ClassVar[str] # e.g. "openai", "qwen", "anthropic", "minimax"
-    resolved_model_id: ClassVar[str] # e.g. "gpt-4o-mini", "qwen/qwen3.6-plus", "anthropic/claude-sonnet-4.6", "minimax/minimax-m2.5"
+    resolved_model_id: ClassVar[str] # e.g. "gpt-5.4", "qwen/qwen3.6-plus", "anthropic/claude-sonnet-4.6", "minimax/minimax-m2.5"
 
     def __init__(self, llm_service: LLMService | None = None) -> None:
         self._llm_service = llm_service or get_llm_service()
@@ -74,7 +74,7 @@ class BaseHarnessLLMModel(ClassifierBaseModel):
 
 class OpenAIModel(BaseHarnessLLMModel):
     alias: ClassVar[str] = "openai"
-    resolved_model_id: ClassVar[str] = "gpt-5-nano"
+    resolved_model_id: ClassVar[str] = "gpt-5.4"
 
 
 class QwenModel(BaseHarnessLLMModel):

--- a/models/llm/providers/openai_provider.py
+++ b/models/llm/providers/openai_provider.py
@@ -29,6 +29,8 @@ class OpenAIProvider(LLMProviderProtocol):
     @property
     def supported_models(self) -> list[str]:
         return [
+            "gpt-5.4",
+            "gpt-5.4-nano",
             "gpt-4o-mini",
             "gpt-4o-mini-2024-07-18",
             "gpt-4",

--- a/models/llm/smoke_tests/openai_examples.py
+++ b/models/llm/smoke_tests/openai_examples.py
@@ -16,7 +16,7 @@ EXAMPLE_TEXTS = [
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     print("Batch example:")
-    batch_results = run_batch_example_query(EXAMPLE_TEXTS, model="gpt-5-nano")
+    batch_results = run_batch_example_query(EXAMPLE_TEXTS, model="gpt-5.4")
     for text, result in zip(EXAMPLE_TEXTS, batch_results, strict=True):
         print(f"Text: {text}\tLabel: {result.label}")
         print("-" * 100)


### PR DESCRIPTION
# PR Description

## Overview

This change makes `gpt-5.4` the repo's default OpenAI model wherever defaults, comments, and examples currently point at `gpt-4o-mini` or `gpt-5-nano`, while also adding `gpt-5.4-nano` to the OpenAI supported model list. We want to use a more up-to-date model. Could've also used `gpt-5.4-nano` as well, but we just wanted to run with GPT 5.4.

## Verification

### Smoke test

```bash
(moral-outrage-classifier) (base) ➜  moral_outrage_classifier git:(update-openai-model) ✗ PYTHONPATH=. uv run python -m evaluation.smoke_tests.model_specific.openai
Smoke test model alias: openai
Resolved model id (CSV/metrics key): gpt-5.4
Smoke test output directory (--output-root): /Users/mark/Documents/work/moral_outrage_classifier/evaluation/smoke_tests/outputs/openai/2026_04_20-17:32:38
Running first eval...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating openai: 100%|████████████████████████████████████████████| 10/10 [00:22<00:00,  2.23s/it]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                         Evaluation Results                         
┏━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Model   ┃ Accuracy ┃ Precision ┃ Recall ┃ F1     ┃ Total Samples ┃
┡━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ gpt-5.4 │ 0.6100   │ 0.5385    │ 0.9333 │ 0.6829 │ 100           │
└─────────┴──────────┴───────────┴────────┴────────┴───────────────┘
First run success: all input rows were classified and artifacts/metrics were validated.
Running second eval (dedup check)...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating openai: 0it [00:00, ?it/s]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                      Evaluation Results                      
┏━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━┳━━━━━━━━━━━━━━━┓
┃ Model ┃ Accuracy ┃ Precision ┃ Recall ┃ F1 ┃ Total Samples ┃
┡━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━╇━━━━━━━━━━━━━━━┩
└───────┴──────────┴───────────┴────────┴────┴───────────────┘
Second run success: deduplication worked and no additional labeling was performed.
Smoke test completed successfully for 'openai'.
```
