### PR TITLE
Migrate Anthropic off OpenRouter to direct API

### DIFF
--- a/evaluation/smoke_tests/model_specific/anthropic.py
+++ b/evaluation/smoke_tests/model_specific/anthropic.py
@@ -1,4 +1,4 @@
-"""Smoke entrypoint: evaluation harness with Anthropic alias (OpenRouter).
+"""Smoke entrypoint: evaluation harness with Anthropic alias (direct Anthropic API).
 
 To run:
 ```bash

--- a/evaluation/smoke_tests/model_specific/anthropic.py
+++ b/evaluation/smoke_tests/model_specific/anthropic.py
@@ -9,4 +9,5 @@ PYTHONPATH=. uv run python -m evaluation.smoke_tests.model_specific.anthropic
 from evaluation.smoke_tests.test_evaluation_harness import run_harness_smoke_test
 
 if __name__ == "__main__":
-    run_harness_smoke_test("anthropic")
+    # Default harness batch is 10; 2 reduces parallel Anthropic TPM/RPM load.
+    run_harness_smoke_test("anthropic", batch_size=2)

--- a/evaluation/smoke_tests/test_evaluation_harness.py
+++ b/evaluation/smoke_tests/test_evaluation_harness.py
@@ -90,6 +90,7 @@ def _run_eval_once(
     output_root: Path,
     input_csv: Path,
     model_alias: str,
+    batch_size: int = 10,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHONPATH"] = "."
@@ -105,7 +106,7 @@ def _run_eval_once(
         "--models",
         model_alias,
         "--batch-size",
-        "10",
+        str(batch_size),
     ]
 
     return subprocess.run(
@@ -241,12 +242,16 @@ def run_harness_smoke_test(
     input_csv: Path | None = None,
     output_root: Path | None = None,
     cleanup: bool | None = None,
+    batch_size: int = 10,
 ) -> None:
     """Run the two-phase harness smoke test for a single model alias.
 
     If ``output_root`` is omitted, uses
     ``evaluation/smoke_tests/outputs/<alias>/<timestamp>/`` and removes it after a
     successful run when cleanup is True (default for that case).
+
+    ``batch_size`` is passed to ``evaluation.examples_test`` (default 10). Lower
+    values reduce parallel LLM completions per batch (e.g. for rate limits).
 
     For pytest, pass ``output_root=tmp_path / "outputs"`` and ``cleanup=False``.
     """
@@ -284,6 +289,7 @@ def run_harness_smoke_test(
             output_root=output_root,
             input_csv=input_path,
             model_alias=model_alias,
+            batch_size=batch_size,
         )
         _assert_run_succeeded(first)
         first_run_dir = _latest_run_dir(output_root)
@@ -303,6 +309,7 @@ def run_harness_smoke_test(
             output_root=output_root,
             input_csv=input_path,
             model_alias=model_alias,
+            batch_size=batch_size,
         )
         _assert_run_succeeded(second)
         second_run_dir = _latest_run_dir(output_root)

--- a/lib/load_env_vars.py
+++ b/lib/load_env_vars.py
@@ -19,6 +19,7 @@ from dotenv import load_dotenv
 
 ENV_VAR_TYPES: Final[dict[str, type[str]]] = {
     "OPENAI_API_KEY": str,
+    "ANTHROPIC_API_KEY": str,
     "OPENROUTER_API_KEY": str,
     "BLUESKY_HANDLE": str,
     "BLUESKY_PASSWORD": str,

--- a/models/llm/config/models.yaml
+++ b/models/llm/config/models.yaml
@@ -43,6 +43,13 @@ models:
           temperature: 1
         }
 
+  anthropic:
+    llm_inference_kwargs:
+      temperature: 0.0
+    supported_models:
+      "anthropic/claude-sonnet-4-6":
+        llm_inference_kwargs: {}
+
   openrouter:
     llm_inference_kwargs:
       temperature: 0.0
@@ -50,6 +57,4 @@ models:
       "qwen/qwen3.6-plus":
         llm_inference_kwargs: {}
       "minimax/minimax-m2.5":
-        llm_inference_kwargs: {}
-      "anthropic/claude-sonnet-4.6":
         llm_inference_kwargs: {}

--- a/models/llm/models.py
+++ b/models/llm/models.py
@@ -14,7 +14,7 @@ class BaseHarnessLLMModel(ClassifierBaseModel):
     """Shared facade for all LLM models."""
 
     alias: ClassVar[str] # e.g. "openai", "qwen", "anthropic", "minimax"
-    resolved_model_id: ClassVar[str] # e.g. "gpt-5.4", "qwen/qwen3.6-plus", "anthropic/claude-sonnet-4.6", "minimax/minimax-m2.5"
+    resolved_model_id: ClassVar[str] # e.g. "gpt-5.4", "qwen/qwen3.6-plus", "anthropic/claude-sonnet-4-6", "minimax/minimax-m2.5"
 
     def __init__(self, llm_service: LLMService | None = None) -> None:
         self._llm_service = llm_service or get_llm_service()
@@ -84,7 +84,7 @@ class QwenModel(BaseHarnessLLMModel):
 
 class AnthropicModel(BaseHarnessLLMModel):
     alias: ClassVar[str] = "anthropic"
-    resolved_model_id: ClassVar[str] = "anthropic/claude-sonnet-4.6"
+    resolved_model_id: ClassVar[str] = "anthropic/claude-sonnet-4-6"
 
 
 class MiniMaxModel(BaseHarnessLLMModel):

--- a/models/llm/providers/anthropic_provider.py
+++ b/models/llm/providers/anthropic_provider.py
@@ -1,4 +1,4 @@
-"""Anthropic provider implementation (direct API via LiteLLM)."""
+"""Anthropic provider implementation."""
 
 import copy
 from typing import Any

--- a/models/llm/providers/anthropic_provider.py
+++ b/models/llm/providers/anthropic_provider.py
@@ -1,4 +1,4 @@
-"""OpenRouter provider implementation."""
+"""Anthropic provider implementation (direct API via LiteLLM)."""
 
 import copy
 from typing import Any
@@ -10,39 +10,33 @@ from models.llm.config.model_registry import ModelConfigRegistry
 from models.llm.providers.base import LLMProviderProtocol
 
 
-class OpenRouterProvider(LLMProviderProtocol):
-    """OpenRouter provider implementation.
+class AnthropicProvider(LLMProviderProtocol):
+    """Anthropic provider: API key from ANTHROPIC_API_KEY, models from config."""
 
-    Handles OpenRouter-specific logic:
-    - API key management (OPENROUTER_API_KEY)
-    - Strict structured-output schema patching (same rules as OpenAI)
-    - LiteLLM model IDs: openrouter/<vendor>/<model>
-    """
-
-    def __init__(self):
+    def __init__(self) -> None:
         self._initialized = False
         self._api_key: str | None = None
 
     @property
     def provider_name(self) -> str:
-        return "openrouter"
+        return "anthropic"
 
     @property
     def supported_models(self) -> list[str]:
-        return ModelConfigRegistry.list_models_for_provider("openrouter")
+        return ModelConfigRegistry.list_models_for_provider("anthropic")
 
     @property
     def api_key(self) -> str:
         if self._api_key is None:
             raise RuntimeError(
-                "OpenRouterProvider has not been initialized with an API key. "
+                "AnthropicProvider has not been initialized with an API key. "
                 "Call initialize() before making LiteLLM requests."
             )
         return self._api_key
 
     def initialize(self, api_key: str | None = None) -> None:
         if api_key is None:
-            api_key = EnvVarsContainer.get_env_var("OPENROUTER_API_KEY", required=True)
+            api_key = EnvVarsContainer.get_env_var("ANTHROPIC_API_KEY", required=True)
         if not self._initialized:
             self._api_key = api_key
             self._initialized = True
@@ -55,10 +49,7 @@ class OpenRouterProvider(LLMProviderProtocol):
         response_model: type[BaseModel],
         model_config: dict[str, Any],
     ) -> dict[str, Any]:
-        """Format OpenAI-compatible structured output for OpenRouter.
-
-        Strict json_schema requires additionalProperties: false on all objects.
-        """
+        """Format strict json_schema for Anthropic (additionalProperties: false on objects)."""
         schema = response_model.model_json_schema()
         fixed_schema = self._fix_schema_for_strict_mode(schema)
 
@@ -71,12 +62,6 @@ class OpenRouterProvider(LLMProviderProtocol):
             },
         }
 
-    def _litellm_model_id(self, public_model_id: str) -> str:
-        """Map public config ID (e.g. qwen/qwen3.6-plus) to LiteLLM OpenRouter form."""
-        if public_model_id.startswith("openrouter/"):
-            return public_model_id
-        return f"openrouter/{public_model_id}"
-
     def prepare_completion_kwargs(
         self,
         model: str,
@@ -85,15 +70,13 @@ class OpenRouterProvider(LLMProviderProtocol):
         model_config: dict[str, Any],
         **kwargs,
     ) -> dict[str, Any]:
-        """Prepare completion kwargs for LiteLLM OpenRouter routing."""
         if not self._initialized:
             self.initialize()
 
-        # Merge model_config defaults with user kwargs (user kwargs take precedence)
         merged_kwargs = {**model_config.get("kwargs", {}), **kwargs}
 
-        completion_kwargs = {
-            "model": self._litellm_model_id(model),
+        completion_kwargs: dict[str, Any] = {
+            "model": model,
             "messages": messages,
             **merged_kwargs,
         }
@@ -110,7 +93,6 @@ class OpenRouterProvider(LLMProviderProtocol):
         return schema_copy
 
     def _patch_recursive(self, obj) -> None:
-        """Recursively patch schema, handling dicts and lists."""
         if isinstance(obj, dict):
             if obj.get("type") == "object":
                 obj["additionalProperties"] = False

--- a/models/llm/providers/registry.py
+++ b/models/llm/providers/registry.py
@@ -1,5 +1,6 @@
 """Registry for LLM providers."""
 
+from models.llm.providers.anthropic_provider import AnthropicProvider
 from models.llm.providers.base import LLMProviderProtocol
 from models.llm.providers.openai_provider import OpenAIProvider
 from models.llm.providers.openrouter_provider import OpenRouterProvider
@@ -56,3 +57,4 @@ class LLMProviderRegistry:
 # classmethods while assuming that the providers are already imported.
 LLMProviderRegistry.register(OpenAIProvider)
 LLMProviderRegistry.register(OpenRouterProvider)
+LLMProviderRegistry.register(AnthropicProvider)

--- a/models/llm/retry.py
+++ b/models/llm/retry.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
 from tenacity import (
+    RetryCallState,
     before_sleep_log,
     retry,
     retry_if_exception,
@@ -12,11 +13,23 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from models.llm.exceptions import ExceptionCategory, LLMException
+try:
+    import litellm.exceptions as litellm_exceptions  # type: ignore[import-untyped]
+except ImportError:
+    litellm_exceptions = None  # type: ignore[assignment]
+
+from models.llm.exceptions import (
+    ExceptionCategory,
+    LLMException,
+    LLMTransientError,
+)
 
 P = ParamSpec("P")
 R = TypeVar("R")
 logger = logging.getLogger(__name__)
+
+ANTHROPIC_MODEL_PREFIX = "anthropic/"
+ANTHROPIC_RATE_LIMIT_SLEEP_SECONDS = 60.0
 
 # Categories that should NOT be retried (fail hard immediately)
 NON_RETRYABLE_CATEGORIES = {
@@ -47,6 +60,50 @@ def _should_retry(exception: BaseException) -> bool:
     return True
 
 
+def _model_from_retry_state(retry_state: RetryCallState) -> str | None:
+    """Resolve `model` from LLMService structured-completion call signatures."""
+    args = retry_state.args
+    if len(args) >= 3:
+        candidate = args[2]
+        return candidate if isinstance(candidate, str) else None
+    return retry_state.kwargs.get("model") if isinstance(retry_state.kwargs, dict) else None
+
+
+def _is_anthropic_litellm_rate_limit(
+    exc: BaseException | None, model: str | None
+) -> bool:
+    if model is None or not model.startswith(ANTHROPIC_MODEL_PREFIX):
+        return False
+    if not isinstance(exc, LLMTransientError) or exc.original_exception is None:
+        return False
+    if litellm_exceptions is None:
+        return False
+    return isinstance(
+        exc.original_exception,
+        litellm_exceptions.RateLimitError,  # type: ignore[attr-defined]
+    )
+
+
+def _wait_anthropic_rate_limit_else_exponential(
+    *,
+    initial_delay: float,
+    max_delay: float,
+) -> Callable[[RetryCallState], float]:
+    jitter = wait_exponential_jitter(initial=initial_delay, max=max_delay)
+
+    def wait(retry_state: RetryCallState) -> float:
+        outcome = retry_state.outcome
+        exc: BaseException | None = None
+        if outcome is not None and outcome.failed:
+            exc = outcome.exception()
+        model = _model_from_retry_state(retry_state)
+        if _is_anthropic_litellm_rate_limit(exc, model):
+            return ANTHROPIC_RATE_LIMIT_SLEEP_SECONDS
+        return jitter(retry_state)
+
+    return wait
+
+
 def retry_llm_completion(
     max_retries: int = 3,
     initial_delay: float = 1.0,
@@ -57,6 +114,10 @@ def retry_llm_completion(
     Retries on ANY exception EXCEPT non-retryable ones (authentication errors,
     invalid requests, etc.). This allows the model to "try again" if it returns
     invalid output, encounters transient HTTP errors, or has missing content.
+
+    For LiteLLM ``RateLimitError`` on models whose id starts with ``anthropic/``,
+    the wait before the next attempt is fixed at 60 seconds so the org TPM/RPM
+    window can clear; all other failures use exponential jitter as before.
 
     Args:
         max_retries: Maximum number of retry attempts (default: 3)
@@ -74,7 +135,10 @@ def retry_llm_completion(
     """
     return retry(
         stop=stop_after_attempt(max_retries + 1),  # +1 for initial attempt
-        wait=wait_exponential_jitter(initial=initial_delay, max=max_delay),
+        wait=_wait_anthropic_rate_limit_else_exponential(
+            initial_delay=initial_delay,
+            max_delay=max_delay,
+        ),
         retry=retry_if_exception(_should_retry),
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,  # Re-raise the exception after all retries exhausted

--- a/models/llm/smoke_tests/anthropic_examples.py
+++ b/models/llm/smoke_tests/anthropic_examples.py
@@ -1,4 +1,4 @@
-"""OpenRouter (Anthropic) smoke-test examples built on shared helpers.
+"""Direct Anthropic smoke-test examples built on shared helpers.
 
 To run:
 
@@ -22,7 +22,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     print("Batch example:")
     batch_results = run_batch_example_query(
-        EXAMPLE_TEXTS, model="anthropic/claude-sonnet-4.6"
+        EXAMPLE_TEXTS, model="anthropic/claude-sonnet-4-6"
     )
     for text, result in zip(EXAMPLE_TEXTS, batch_results, strict=True):
         print(f"Text: {text}\tLabel: {result.label}")

--- a/tests/evaluation/test_dataloader.py
+++ b/tests/evaluation/test_dataloader.py
@@ -5,7 +5,7 @@ import pytest
 
 from evaluation.dataloader import DataLoader
 from evaluation.metadata import get_model_id_value
-from models.llm.models import OpenAIModel
+from models.llm.models import AnthropicModel, OpenAIModel
 
 
 # Input file fixtures
@@ -197,6 +197,13 @@ class TestGetUniqueModelRunIdentifier:
         resolved_id, prompt_hash = loader.get_unique_model_run_identifier()
         assert resolved_id == get_model_id_value("openai")
         assert prompt_hash == OpenAIModel.get_prompt_hash()
+
+    def test_anthropic_returns_resolved_id_and_prompt_hash(self, input_file_with_rows, tmp_path):
+        loader = DataLoader(str(input_file_with_rows), str(tmp_path), batch_size=10, model_name="anthropic")
+        resolved_id, prompt_hash = loader.get_unique_model_run_identifier()
+        assert resolved_id == get_model_id_value("anthropic")
+        assert resolved_id == AnthropicModel.get_resolved_model_id()
+        assert prompt_hash == AnthropicModel.get_prompt_hash()
 
     def test_perspective_returns_alias_and_no_prompt_hash(self, input_file_with_rows, tmp_path):
         loader = DataLoader(str(input_file_with_rows), str(tmp_path), batch_size=10, model_name="perspective_api")

--- a/tests/models/llm/test_anthropic_provider.py
+++ b/tests/models/llm/test_anthropic_provider.py
@@ -1,0 +1,45 @@
+"""AnthropicProvider behavior."""
+
+import pytest
+
+from lib.load_env_vars import EnvVarsContainer
+from models.llm.providers.anthropic_provider import AnthropicProvider
+
+
+def test_prepare_completion_kwargs_forwards_response_format_when_present() -> None:
+    provider = AnthropicProvider()
+    provider.initialize(api_key="test-key")
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "dummyresponse",
+            "strict": True,
+            "schema": {"type": "object", "properties": {"label": {"type": "integer"}}},
+        },
+    }
+    out = provider.prepare_completion_kwargs(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "x"}],
+        response_format=response_format,
+        model_config={"kwargs": {}},
+    )
+    assert out["response_format"] == response_format
+
+
+def test_initialize_without_api_key_requires_anthropic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get_env_var(cls, name: str, required: bool = False) -> str:
+        if name == "ANTHROPIC_API_KEY" and required:
+            raise ValueError(
+                "ANTHROPIC_API_KEY is required but is missing. "
+                "Please set the ANTHROPIC_API_KEY environment variable."
+            )
+        return ""
+
+    monkeypatch.setattr(
+        EnvVarsContainer,
+        "get_env_var",
+        classmethod(fake_get_env_var),
+    )
+    provider = AnthropicProvider()
+    with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+        provider.initialize()

--- a/tests/models/llm/test_env_loading.py
+++ b/tests/models/llm/test_env_loading.py
@@ -1,0 +1,8 @@
+"""Environment variable registration for LLM providers."""
+
+from lib.load_env_vars import ENV_VAR_TYPES
+
+
+def test_anthropic_api_key_registered() -> None:
+    assert "ANTHROPIC_API_KEY" in ENV_VAR_TYPES
+    assert ENV_VAR_TYPES["ANTHROPIC_API_KEY"] is str

--- a/tests/models/llm/test_provider_registry.py
+++ b/tests/models/llm/test_provider_registry.py
@@ -1,0 +1,15 @@
+"""LLM provider registry routing."""
+
+from models.llm.providers.anthropic_provider import AnthropicProvider
+from models.llm.providers.openrouter_provider import OpenRouterProvider
+from models.llm.providers.registry import LLMProviderRegistry
+
+
+def test_anthropic_claude_sonnet_resolves_to_anthropic_provider() -> None:
+    provider = LLMProviderRegistry.get_provider("anthropic/claude-sonnet-4-6")
+    assert isinstance(provider, AnthropicProvider)
+
+
+def test_qwen_resolves_to_openrouter_provider() -> None:
+    provider = LLMProviderRegistry.get_provider("qwen/qwen3.6-plus")
+    assert isinstance(provider, OpenRouterProvider)


### PR DESCRIPTION
## Overview

We are migrating Anthropic to a direct provider integration and removing all OpenRouter-specific Anthropic routing. We've found OpenRouter to be a bit slow, so using the direct Anthropic integration has better results.

The current org limit for tpm (tokens per minute) is pretty low, hence the updates to the retry logic to try to get around it (as much as possible; we still hit it, but that's a problem to be solved later).

## Verification

### Smoke tests

```bash
(moral-outrage-classifier) (base) ➜  moral_outrage_classifier git:(migrate-anthropic-direct-off-openrouter) ✗ PYTHONPATH=. uv run python -m evaluation.smoke_tests.model_specific.anthropic
Smoke test model alias: anthropic
Resolved model id (CSV/metrics key): anthropic/claude-sonnet-4-6
Smoke test output directory (--output-root): /Users/mark/Documents/work/moral_outrage_classifier/evaluation/smoke_tests/outputs/anthropic/2026_04_20-17:54:11
Running first eval...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating anthropic:  30%|████████████▎                            | 15/50 [00:25<00:57,  1.63s/it]Retrying models.llm.llm_service.LLMService._complete_and_validate_structured_batch in 60 seconds as it raised LLMTransientError: litellm.RateLimitError: AnthropicException - {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your organization's rate limit of 30,000 input tokens per minute (org: 610a2a17-f4a5-4c21-b60d-9753e9213cfa, model: claude-sonnet-4-6). For details, refer to: https://docs.claude.com/en/api/rate-limits. You can see the response headers for current usage. Please reduce the prompt length or the maximum tokens requested, or try again later. You may also contact sales at https://claude.com/contact-sales to discuss your options for a rate limit increase."},"request_id":"req_011CaFTAtiMvbNAEeqgj3uDT"}.
Evaluating anthropic:  60%|████████████████████████▌                | 30/50 [01:48<00:29,  1.48s/it]Retrying models.llm.llm_service.LLMService._complete_and_validate_structured_batch in 60 seconds as it raised LLMTransientError: litellm.RateLimitError: AnthropicException - {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your organization's rate limit of 30,000 input tokens per minute (org: 610a2a17-f4a5-4c21-b60d-9753e9213cfa, model: claude-sonnet-4-6). For details, refer to: https://docs.claude.com/en/api/rate-limits. You can see the response headers for current usage. Please reduce the prompt length or the maximum tokens requested, or try again later. You may also contact sales at https://claude.com/contact-sales to discuss your options for a rate limit increase."},"request_id":"req_011CaFTH4vSX7PqJX4mGEsXe"}.
Evaluating anthropic:  88%|████████████████████████████████████     | 44/50 [03:09<00:09,  1.59s/it]Retrying models.llm.llm_service.LLMService._complete_and_validate_structured_batch in 60 seconds as it raised LLMTransientError: litellm.RateLimitError: AnthropicException - {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your organization's rate limit of 30,000 input tokens per minute (org: 610a2a17-f4a5-4c21-b60d-9753e9213cfa, model: claude-sonnet-4-6). For details, refer to: https://docs.claude.com/en/api/rate-limits. You can see the response headers for current usage. Please reduce the prompt length or the maximum tokens requested, or try again later. You may also contact sales at https://claude.com/contact-sales to discuss your options for a rate limit increase."},"request_id":"req_011CaFTP2fRkV58i9gMSaqMT"}.
Evaluating anthropic: 100%|█████████████████████████████████████████| 50/50 [04:17<00:00,  5.15s/it]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                                   Evaluation Results                                   
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Model                       ┃ Accuracy ┃ Precision ┃ Recall ┃ F1     ┃ Total Samples ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ anthropic/claude-sonnet-4-6 │ 0.6000   │ 0.5301    │ 0.9778 │ 0.6875 │ 100           │
└─────────────────────────────┴──────────┴───────────┴────────┴────────┴───────────────┘
First run success: all input rows were classified and artifacts/metrics were validated.
Running second eval (dedup check)...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating anthropic: 0it [00:00, ?it/s]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                      Evaluation Results                      
┏━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━┳━━━━━━━━━━━━━━━┓
┃ Model ┃ Accuracy ┃ Precision ┃ Recall ┃ F1 ┃ Total Samples ┃
┡━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━╇━━━━━━━━━━━━━━━┩
└───────┴──────────┴───────────┴────────┴────┴───────────────┘
Second run success: deduplication worked and no additional labeling was performed.
Smoke test completed successfully for 'anthropic'.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct Anthropic provider added with structured-output formatting
  * ANTHROPIC_API_KEY environment variable supported

* **Updates**
  * Anthropic model identifier format and default temperature updated
  * Provider registry and model routing include Anthropic models
  * Evaluation harness exposes configurable batch-size for runs

* **Reliability**
  * Improved retry/backoff logic for Anthropic rate-limit errors

* **Tests**
  * New tests covering Anthropic provider, env loading, and registry routing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->