### PR TITLE
Set up AWS Bedrock access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,17 @@ htmlcov/
 .DS_Store
 
 *.env
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+*.tfvars
+terraform.tfvars.json
+.terraform.lock.hcl
+# Local .auto.tfvars files containing secrets or environment overrides
+*.auto.tfvars
+*.auto.tfvars.json
+# Terraform plan outputs
+*.tfplan

--- a/docs/runbooks/HOW_TO_RUN_AWS_BEDROCK.md
+++ b/docs/runbooks/HOW_TO_RUN_AWS_BEDROCK.md
@@ -1,0 +1,111 @@
+---
+description: How to provision IAM access and run the Amazon Bedrock Qwen smoke test
+tags: [aws, bedrock, qwen, terraform, experiments]
+---
+
+# Amazon Bedrock Qwen Runbook
+
+This runbook verifies that this repo can invoke Qwen3 32B through Amazon Bedrock without provisioning a model endpoint.
+
+## What This Uses
+
+- AWS region: `us-east-2`
+- Bedrock Runtime model ID: `qwen.qwen3-32b-v1:0`
+- Python entry point: `experiments/2026-04-24_aws_bedrock/experiment.py`
+- Terraform entry point: `terraform/main.tf`
+
+Use `us-east-2` for AWS.
+
+## Prerequisites
+
+Install local dependencies:
+
+```bash
+uv sync
+```
+
+Authenticate to AWS with a principal that can create IAM policies and, if desired, attach them:
+
+```bash
+aws sts get-caller-identity
+```
+
+If you use AWS SSO:
+
+```bash
+aws sso login --profile <your-profile>
+export AWS_PROFILE=<your-profile>
+export AWS_REGION=us-east-2
+```
+
+## Provision IAM Permissions
+
+The Terraform creates a least-privilege managed IAM policy that allows invoking only the Qwen3 32B Bedrock foundation model in `us-east-2`.
+
+From the repository root:
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+That creates the policy and prints its ARN. If you want Terraform to attach the policy to an IAM role or user during apply, pass the relevant name:
+
+```bash
+terraform apply \
+  -var='attach_to_iam_role_names=["<role-name>"]'
+```
+
+or:
+
+```bash
+terraform apply \
+  -var='attach_to_iam_user_names=["<user-name>"]'
+```
+
+If you are using an AWS SSO permission-set role, you may need to attach the generated policy through your organization's IAM Identity Center workflow instead of attaching it directly with this Terraform.
+
+Return to the repository root:
+
+```bash
+cd ..
+```
+
+## Run The Smoke Test
+
+With AWS credentials available in your shell:
+
+```bash
+PYTHONPATH=. uv run python experiments/2026-04-24_aws_bedrock/experiment.py
+```
+
+To use an explicit profile:
+
+```bash
+PYTHONPATH=. uv run python experiments/2026-04-24_aws_bedrock/experiment.py \
+  --profile <your-profile>
+```
+
+To customize the prompt:
+
+```bash
+PYTHONPATH=. uv run python experiments/2026-04-24_aws_bedrock/experiment.py \
+  --prompt "Classify whether this sentence expresses moral outrage: How dare they let children go hungry while executives collect bonuses."
+```
+
+Expected output includes:
+
+- The model ID and region being invoked.
+- Generated text, when it can be extracted from the response.
+- Elapsed wall-clock time in milliseconds.
+- The raw JSON response from Bedrock.
+
+## Troubleshooting
+
+- `AccessDeniedException`: Confirm the active principal has `bedrock:InvokeModel` on `arn:aws:bedrock:us-east-2::foundation-model/qwen.qwen3-32b-v1:0`.
+- `ResourceNotFoundException`: Confirm the region is `us-east-2` and the model ID is `qwen.qwen3-32b-v1:0`.
+- `Unable to locate credentials`: Run `aws sts get-caller-identity`; if it fails, refresh your AWS credentials or run `aws sso login`.
+- `ValidationException`: Check that the request body uses `messages`, `max_tokens`, and `temperature`, not Titan-style `inputText`.
+- Slow first request: Bedrock is managed/serverless, but first calls can be slower than warm calls. Run the script a few times before comparing latency with OpenRouter.

--- a/experiments/2026-04-24_aws_bedrock/experiment.py
+++ b/experiments/2026-04-24_aws_bedrock/experiment.py
@@ -1,0 +1,131 @@
+"""Smoke test for invoking Qwen3 32B through Amazon Bedrock.
+
+Run from the repository root:
+
+PYTHONPATH=. uv run python experiments/2026-04-24_aws_bedrock/experiment.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+DEFAULT_MODEL_ID = "qwen.qwen3-32b-v1:0"
+DEFAULT_REGION = "us-east-2"
+DEFAULT_PROMPT = "Write a concise summary of Amazon Bedrock."
+
+
+def extract_text(payload: dict[str, Any]) -> str:
+    """Best-effort text extraction while still printing the raw response below."""
+
+    choices = payload.get("choices")
+    if isinstance(choices, list) and choices:
+        first_choice = choices[0]
+        if isinstance(first_choice, dict):
+            message = first_choice.get("message")
+            if isinstance(message, dict) and isinstance(message.get("content"), str):
+                return message["content"]
+            if isinstance(first_choice.get("text"), str):
+                return first_choice["text"]
+
+    for key in ("text", "output_text", "generated_text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+
+    output = payload.get("output")
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        message = output.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, list):
+                text_blocks = [
+                    block["text"]
+                    for block in content
+                    if isinstance(block, dict) and isinstance(block.get("text"), str)
+                ]
+                if text_blocks:
+                    return "\n".join(text_blocks)
+
+    return ""
+
+
+def invoke_qwen(
+    *,
+    prompt: str,
+    model_id: str,
+    max_tokens: int,
+    temperature: float,
+    profile: str | None,
+) -> dict[str, Any]:
+    session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    client = session.client("bedrock-runtime", region_name=DEFAULT_REGION)
+
+    response = client.invoke_model(
+        modelId=model_id,
+        contentType="application/json",
+        accept="application/json",
+        body=json.dumps(
+            {
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+        ),
+    )
+
+    return json.loads(response["body"].read())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--model-id", default=os.getenv("BEDROCK_MODEL_ID", DEFAULT_MODEL_ID))
+    parser.add_argument("--region", default=os.getenv("AWS_REGION", DEFAULT_REGION))
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument(
+        "--profile",
+        default=os.getenv("AWS_PROFILE"),
+        help="Optional AWS profile name. Defaults to AWS_PROFILE when set.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    print(f"Invoking {args.model_id} in {DEFAULT_REGION}...")
+    start = time.perf_counter()
+    try:
+        payload = invoke_qwen(
+            prompt=args.prompt,
+            model_id=args.model_id,
+            max_tokens=args.max_tokens,
+            temperature=args.temperature,
+            profile=args.profile,
+        )
+    except (BotoCoreError, ClientError) as exc:
+        raise SystemExit(f"Bedrock invocation failed: {exc}") from exc
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    text = extract_text(payload)
+    if text:
+        print("\nGenerated text:")
+        print(text)
+
+    print(f"\nElapsed: {elapsed_ms:.0f} ms")
+    print("\nRaw response:")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/2026-04-24_aws_bedrock/experiment.py
+++ b/experiments/2026-04-24_aws_bedrock/experiment.py
@@ -89,7 +89,6 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prompt", default=DEFAULT_PROMPT)
     parser.add_argument("--model-id", default=os.getenv("BEDROCK_MODEL_ID", DEFAULT_MODEL_ID))
-    parser.add_argument("--region", default=os.getenv("AWS_REGION", DEFAULT_REGION))
     parser.add_argument("--max-tokens", type=int, default=256)
     parser.add_argument("--temperature", type=float, default=0.2)
     parser.add_argument(
@@ -102,8 +101,6 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-
-    print(f"Invoking {args.model_id} in {DEFAULT_REGION}...")
     start = time.perf_counter()
     try:
         payload = invoke_qwen(

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,3 @@
+# Experiments
+
+One-off experimental files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 requires-python = ">=3.12"
 dependencies = [
+    "boto3>=1.42.96",
     "google-api-python-client>=2.193.0",
     "langdetect>=1.0.9",
     "litellm==1.81.0",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for Bedrock runtime calls."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "bedrock_model_id" {
+  description = "Bedrock foundation model ID to allow invoking."
+  type        = string
+  default     = "qwen.qwen3-32b-v1:0"
+}
+
+variable "attach_to_iam_user_names" {
+  description = "Optional IAM user names that should receive the Bedrock invoke policy."
+  type        = set(string)
+  default     = []
+}
+
+variable "attach_to_iam_role_names" {
+  description = "Optional IAM role names that should receive the Bedrock invoke policy."
+  type        = set(string)
+  default     = []
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_partition" "current" {}
+
+locals {
+  qwen_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${var.aws_region}::foundation-model/${var.bedrock_model_id}"
+}
+
+data "aws_iam_policy_document" "bedrock_qwen_invoke" {
+  statement {
+    sid    = "InvokeQwenOnBedrock"
+    effect = "Allow"
+
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+
+    resources = [local.qwen_model_arn]
+  }
+}
+
+resource "aws_iam_policy" "bedrock_qwen_invoke" {
+  name        = "BedrockQwenInvoke"
+  description = "Allows invoking ${var.bedrock_model_id} through Amazon Bedrock Runtime."
+  policy      = data.aws_iam_policy_document.bedrock_qwen_invoke.json
+}
+
+resource "aws_iam_user_policy_attachment" "bedrock_qwen_invoke" {
+  for_each = var.attach_to_iam_user_names
+
+  user       = each.value
+  policy_arn = aws_iam_policy.bedrock_qwen_invoke.arn
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock_qwen_invoke" {
+  for_each = var.attach_to_iam_role_names
+
+  role       = each.value
+  policy_arn = aws_iam_policy.bedrock_qwen_invoke.arn
+}
+
+output "bedrock_qwen_model_arn" {
+  description = "ARN of the Bedrock Qwen foundation model allowed by this policy."
+  value       = local.qwen_model_arn
+}
+
+output "bedrock_qwen_policy_arn" {
+  description = "Managed IAM policy ARN for invoking the Bedrock Qwen model."
+  value       = aws_iam_policy.bedrock_qwen_invoke.arn
+}


### PR DESCRIPTION
# PR Description

Sets up AWS Bedrock access. 

Steps:
1. Write Terraform to create an AWS access policy for accessing AWS Bedrock.
2. Run the `experiments/2026-04-24_aws_bedrock/experiment.py` to see it in action.
3. Add `docs/runbooks/HOW_TO_RUN_AWS_BEDROCK.md` runbook for steps on how to get AWS Bedrock up and running.

## Verification

```bash
(base) ➜  moral_outrage_classifier git:(setup-aws-bedrock) ✗ PYTHONPATH=. uv run python experiments/2026-04-24_aws_bedrock/experiment.py
Invoking qwen.qwen3-32b-v1:0 in us-east-2...

Generated text:
Amazon Bedrock is a managed service by AWS that provides access to a range of foundation models (FMs) developed by leading AI companies. It enables developers and businesses to build and scale generative AI applications using pre-trained models for tasks like text generation, code writing, and data analysis. Bedrock supports customization through fine-tuning and integration with AWS services, offering a secure and scalable platform for deploying AI solutions.

Elapsed: 683 ms

Raw response:
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "logprobs": null,
      "message": {
        "content": "Amazon Bedrock is a managed service by AWS that provides access to a range of foundation models (FMs) developed by leading AI companies. It enables developers and businesses to build and scale generative AI applications using pre-trained models for tasks like text generation, code writing, and data analysis. Bedrock supports customization through fine-tuning and integration with AWS services, offering a secure and scalable platform for deploying AI solutions.",
        "refusal": null,
        "role": "assistant"
      }
    }
  ],
  "created": 1777071068,
  "id": "chatcmpl-58236bc9-5d59-499f-b350-2f6e8faa4411",
  "model": "qwen.qwen3-32b-v1:0",
  "object": "chat.completion",
  "service_tier": "default",
  "usage": {
    "completion_tokens": 84,
    "prompt_tokens": 21,
    "total_tokens": 105
  }
}
```

We can look at AWS CloudWatch and see the 1 invocation, corresponding to running the experimental script 1 time.

<img width="1728" height="1117" alt="Screenshot 2026-04-24 at 5 57 24 PM" src="https://github.com/user-attachments/assets/0be64717-1ec2-4d93-855c-1275b87f380a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock integration with a CLI smoke-test for invoking models, customizable prompt/model/params, and basic response extraction and timing output.
  * Added Terraform configuration to create and optionally attach IAM policies for Bedrock model invocation.

* **Chores**
  * Updated .gitignore to ignore Terraform artifacts and state files.
  * Added boto3 dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->