### PR TITLE
Move Qwen from OpenRouter to AWS Bedrock

### DIFF
--- a/docs/plans/2026-04-24_add_qwen_bedrock/plan.md
+++ b/docs/plans/2026-04-24_add_qwen_bedrock/plan.md
@@ -1,0 +1,145 @@
+---
+name: qwen bedrock provider
+overview: Build a new AWS Bedrock LLM provider so existing Qwen usage continues to call `model="qwen/qwen3.6-plus"` and `run_harness_smoke_test("qwen")`, but provider internals route requests through Amazon Bedrock model `qwen.qwen3-32b-v1:0` in `us-east-2`. Evaluation outputs, metrics keys, and deduplication identity remain `qwen/qwen3.6-plus` per the chosen identity policy.
+todos:
+  - id: auth-boundary
+    content: Update provider API-key contract so Bedrock can authenticate through AWS credentials without a fake api_key.
+    status: pending
+  - id: bedrock-provider
+    content: Add BedrockProvider with qwen/qwen3.6-plus to bedrock/qwen.qwen3-32b-v1:0 mapping and us-east-2 AWS kwargs.
+    status: pending
+  - id: config-routing
+    content: Move Qwen from OpenRouter to Bedrock in models.yaml and register BedrockProvider.
+    status: pending
+  - id: tests
+    content: Update provider registry tests and add Bedrock provider kwargs/auth tests.
+    status: pending
+  - id: smoke-verify
+    content: Run unchanged Qwen model and evaluation smoke tests against AWS Bedrock.
+    status: pending
+isProject: false
+---
+
+# Qwen Bedrock Provider Plan
+
+## Remember
+
+- Exact file paths always
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+- Maximum safely delegable parallelism
+- Delegated tasks must be impossible to misread
+
+## Overview
+
+Build a new Bedrock provider under `[models/llm/providers/](models/llm/providers/)` and update `[models/llm/config/models.yaml](models/llm/config/models.yaml)` so repo-facing Qwen usage remains unchanged while LiteLLM routes to AWS Bedrock. The public model id, evaluation metadata, metrics keys, and deduplication identity will remain `qwen/qwen3.6-plus`; only provider internals translate to `bedrock/qwen.qwen3-32b-v1:0`.
+
+Plan assets path: `[docs/plans/2026-04-24_qwen_bedrock_provider_482913/](docs/plans/2026-04-24_qwen_bedrock_provider_482913/)`.
+
+## Happy Flow
+
+1. `[models/llm/smoke_tests/qwen_examples.py](models/llm/smoke_tests/qwen_examples.py)` continues to call `run_batch_example_query(..., model="qwen/qwen3.6-plus")` with no public API change.
+2. `[models/llm/models.py](models/llm/models.py)` keeps `QwenModel.resolved_model_id = "qwen/qwen3.6-plus"`, so evaluation metadata, metrics, and deduplication continue using the current identity.
+3. `[models/llm/providers/registry.py](models/llm/providers/registry.py)` resolves `qwen/qwen3.6-plus` to the new `BedrockProvider` because `[models/llm/config/models.yaml](models/llm/config/models.yaml)` lists Qwen under `models.bedrock.supported_models`.
+4. `BedrockProvider.prepare_completion_kwargs(...)` maps `qwen/qwen3.6-plus` to LiteLLM model `bedrock/qwen.qwen3-32b-v1:0`, merges config kwargs, attaches `aws_region_name="us-east-2"`, and optionally attaches `aws_profile_name` from configuration or `AWS_PROFILE`.
+5. `[models/llm/llm_service.py](models/llm/llm_service.py)` calls `litellm.completion` or `batch_completion` without forcing an API key for Bedrock, letting AWS credentials resolve through LiteLLM/boto3.
+6. LiteLLM returns OpenAI-shaped responses, and existing structured parsing in `LLMService.handle_completion_response(...)` and `handle_batch_completion_responses(...)` remains unchanged.
+
+```mermaid
+flowchart LR
+  qwenSmoke["qwen_examples.py"] --> publicId["qwen/qwen3.6-plus"]
+  evalHarness["evaluation qwen alias"] --> publicId
+  publicId --> registry["LLMProviderRegistry"]
+  registry --> bedrockProvider["BedrockProvider"]
+  bedrockProvider --> runtimeId["bedrock/qwen.qwen3-32b-v1:0"]
+  runtimeId --> liteLLM["LiteLLM Bedrock"]
+  liteLLM --> awsBedrock["AWS Bedrock us-east-2"]
+```
+
+
+
+## Interface Or Contract Freeze
+
+- Public Qwen model id remains `qwen/qwen3.6-plus`.
+- `QwenModel.resolved_model_id` in `[models/llm/models.py](models/llm/models.py)` remains `qwen/qwen3.6-plus`.
+- `[models/llm/smoke_tests/qwen_examples.py](models/llm/smoke_tests/qwen_examples.py)` remains behaviorally identical: no caller-visible model string change.
+- `[evaluation/smoke_tests/model_specific/qwen.py](evaluation/smoke_tests/model_specific/qwen.py)` remains behaviorally identical: still calls `run_harness_smoke_test("qwen")`.
+- `OpenRouterProvider` continues to support `minimax/minimax-m2.5`; it must no longer support `qwen/qwen3.6-plus`.
+- Bedrock auth uses AWS credentials/region/profile, not `OPENROUTER_API_KEY`.
+- No UI files are involved, so no screenshots are required.
+
+## Serial Coordination Spine
+
+1. Update provider protocol/API-key handling first because all providers pass through `[models/llm/llm_service.py](models/llm/llm_service.py)`.
+2. Add `BedrockProvider` and register it.
+3. Move Qwen config from `openrouter` to `bedrock` in `[models/llm/config/models.yaml](models/llm/config/models.yaml)`.
+4. Update tests to assert Qwen routes to Bedrock and OpenRouter still handles MiniMax.
+5. Run focused tests, then live smoke tests with AWS credentials.
+
+## Parallel Task Packets
+
+### Task A: Bedrock Provider Unit
+
+- Objective: Add `BedrockProvider` with config-backed supported models and LiteLLM Bedrock model mapping.
+- Why parallelizable: It can be implemented against the frozen provider protocol once the optional API-key contract is known.
+- Inspect: `[models/llm/providers/openrouter_provider.py](models/llm/providers/openrouter_provider.py)`, `[models/llm/providers/anthropic_provider.py](models/llm/providers/anthropic_provider.py)`, `[experiments/2026-04-24_aws_bedrock/experiment.py](experiments/2026-04-24_aws_bedrock/experiment.py)`.
+- Allowed to change: `[models/llm/providers/bedrock_provider.py](models/llm/providers/bedrock_provider.py)`.
+- Forbidden to change: `[models/llm/models.py](models/llm/models.py)`, smoke-test entrypoints, evaluation harness.
+- Preconditions: Optional API-key contract is finalized.
+- Required invariants: public model id in, LiteLLM Bedrock model id out; region defaults to `us-east-2`; structured output format remains JSON schema compatible with existing service parsing.
+- Verification: `PYTHONPATH=. uv run pytest tests/models/llm -q` should pass after integration tests are added.
+
+### Task B: Registry And Config Routing
+
+- Objective: Route `qwen/qwen3.6-plus` to Bedrock and leave MiniMax on OpenRouter.
+- Why parallelizable: Config and registry changes are isolated from provider implementation once class name and provider name are frozen.
+- Inspect: `[models/llm/config/models.yaml](models/llm/config/models.yaml)`, `[models/llm/providers/registry.py](models/llm/providers/registry.py)`, `[tests/models/llm/test_provider_registry.py](tests/models/llm/test_provider_registry.py)`.
+- Allowed to change: those three files only.
+- Forbidden to change: `[models/llm/models.py](models/llm/models.py)`.
+- Preconditions: `BedrockProvider.provider_name == "bedrock"`.
+- Required invariants: `qwen/qwen3.6-plus` appears under `models.bedrock.supported_models`; it does not appear under `models.openrouter.supported_models`.
+- Verification: provider registry tests assert Qwen resolves to `BedrockProvider` and MiniMax resolves to `OpenRouterProvider`.
+
+### Task C: LLMService Auth Boundary
+
+- Objective: Let providers opt out of `api_key` so Bedrock can use AWS credentials.
+- Why parallelizable: This is a small contract change with clear behavior.
+- Inspect: `[models/llm/providers/base.py](models/llm/providers/base.py)`, `[models/llm/llm_service.py](models/llm/llm_service.py)`, existing providers.
+- Allowed to change: `[models/llm/providers/base.py](models/llm/providers/base.py)`, `[models/llm/llm_service.py](models/llm/llm_service.py)`, provider classes only if typing requires it.
+- Forbidden to change: evaluation files and smoke-test files.
+- Preconditions: Provider protocol decision: `api_key` returns `str | None`.
+- Required invariants: OpenAI, Anthropic, and OpenRouter still pass `api_key`; Bedrock does not.
+- Verification: existing provider tests pass and a Bedrock provider test confirms no fake key is required.
+
+## Integration Order
+
+1. Land Task C first: update provider protocol and `LLMService` to conditionally include `api_key` only when not `None`.
+2. Land Task A: add `BedrockProvider` with public-to-runtime id mapping and AWS kwargs.
+3. Land Task B: register Bedrock, move Qwen config, and update registry tests.
+4. Add or update provider-specific tests for Bedrock completion kwargs.
+5. Run offline tests before any live AWS smoke tests.
+
+## Manual Verification
+
+- Run `PYTHONPATH=. uv run pytest tests/models/llm -q`. Expected: all model/provider tests pass, including Qwen resolving to `BedrockProvider`.
+- Confirm OpenRouter no longer requires `OPENROUTER_API_KEY` for Qwen by running with AWS credentials only: `AWS_REGION=us-east-2 PYTHONPATH=. uv run python -m models.llm.smoke_tests.qwen_examples`. Expected: batch labels print for all example texts.
+- Run the existing evaluation smoke test unchanged: `AWS_REGION=us-east-2 PYTHONPATH=. uv run python -m evaluation.smoke_tests.model_specific.qwen`. Expected: first run classifies all rows, second run dedupes to zero incremental rows.
+- Inspect the smoke output logs. Expected: resolved model id printed by the harness remains `qwen/qwen3.6-plus`.
+- If using AWS SSO, first run `aws sso login --profile <profile>` and then `AWS_PROFILE=<profile> AWS_REGION=us-east-2 PYTHONPATH=. uv run python -m models.llm.smoke_tests.qwen_examples`.
+
+## Final Verification
+
+- `qwen/qwen3.6-plus` remains the public and evaluation identity.
+- `BedrockProvider.prepare_completion_kwargs(...)` sends `model="bedrock/qwen.qwen3-32b-v1:0"` to LiteLLM.
+- `OPENROUTER_API_KEY` is no longer needed for Qwen.
+- Existing MiniMax/OpenRouter behavior remains intact.
+- Existing OpenAI and Anthropic provider tests remain intact.
+- Live Qwen smoke tests succeed against Bedrock in `us-east-2`.
+
+## Alternative Approaches
+
+- Expose `bedrock/qwen.qwen3-32b-v1:0` directly to callers: rejected because public-facing usage must remain identical.
+- Store Bedrock identity in evaluation metadata and dedup keys: rejected per chosen policy to preserve `qwen/qwen3.6-plus` as the resolved model id.
+- Return a fake Bedrock API key from `BedrockProvider`: rejected because Bedrock uses AWS credentials and the service boundary should model that truthfully.
+- Bypass LiteLLM and call boto3 directly in `BedrockProvider`: rejected initially because the existing provider architecture is LiteLLM-based and PR #38 already showed LiteLLM-compatible response shape through Bedrock.
+

--- a/evaluation/run_evaluation_harness.py
+++ b/evaluation/run_evaluation_harness.py
@@ -82,7 +82,7 @@ class EvaluationHarness:
                     if model_name == "perspective_api":
                         pred_label = 1 if prediction.moral_outrage_score > PROB_LABEL_THRESHOLD else 0
                     else:
-                        pred_label = prediction.moral_outrage_score 
+                        pred_label = int(prediction.moral_outrage_score)
 
                 is_correct = int(sample["gold_label"]) == int(pred_label) if pred_label is not None and sample["gold_label"] is not None else None
 
@@ -93,7 +93,7 @@ class EvaluationHarness:
                     "gold_label": sample["gold_label"],
                     "pred_label": pred_label,
                     "is_correct": is_correct,
-                    "model": model_name,
+                    "model": csv_model,
                 })
     
     @retry(stop=stop_after_attempt(RETRIES), wait=wait_fixed(RETRY_WAIT_TIME_SECONDS))

--- a/lib/aws/__init__.py
+++ b/lib/aws/__init__.py
@@ -1,0 +1,1 @@
+"""AWS service client wrappers."""

--- a/lib/aws/bedrock.py
+++ b/lib/aws/bedrock.py
@@ -1,0 +1,36 @@
+"""Wrapper client for Amazon Bedrock Runtime."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import boto3
+
+DEFAULT_BEDROCK_REGION = "us-east-2"
+
+
+class BedrockClient:
+    """Wrapper class for Bedrock Runtime access."""
+
+    def __init__(
+        self,
+        *,
+        region_name: str = DEFAULT_BEDROCK_REGION,
+        profile_name: str | None = None,
+    ) -> None:
+        self.region_name = region_name
+        self.profile_name = profile_name if profile_name is not None else os.getenv("AWS_PROFILE")
+        session = (
+            boto3.Session(profile_name=self.profile_name)
+            if self.profile_name
+            else boto3.Session()
+        )
+        self.client = session.client("bedrock-runtime", region_name=self.region_name)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate Bedrock Runtime API access to the boto3 client."""
+        try:
+            return getattr(self.client, name)
+        except AttributeError:
+            raise AttributeError(f"'BedrockClient' object has no attribute '{name}'")

--- a/models/llm/config/models.yaml
+++ b/models/llm/config/models.yaml
@@ -50,11 +50,16 @@ models:
       "anthropic/claude-sonnet-4-6":
         llm_inference_kwargs: {}
 
-  openrouter:
+  bedrock:
     llm_inference_kwargs:
       temperature: 0.0
     supported_models:
       "qwen/qwen3.6-plus":
         llm_inference_kwargs: {}
+
+  openrouter:
+    llm_inference_kwargs:
+      temperature: 0.0
+    supported_models:
       "minimax/minimax-m2.5":
         llm_inference_kwargs: {}

--- a/models/llm/llm_service.py
+++ b/models/llm/llm_service.py
@@ -150,8 +150,11 @@ class LLMService:
             **kwargs,
         )
         completion_kwargs["messages"] = messages
-        # Avoid global LiteLLM state; use the provider instance's key per request.
-        completion_kwargs["api_key"] = provider.api_key
+        # Avoid global LiteLLM state; use the provider instance's key per request
+        # when that provider authenticates with an API key.
+        api_key = provider.api_key
+        if api_key is not None:
+            completion_kwargs["api_key"] = api_key
 
         try:
             result = litellm.completion(**completion_kwargs)  # type: ignore
@@ -203,8 +206,11 @@ class LLMService:
         # Remove placeholder messages from kwargs since batch_completion takes it separately
         completion_kwargs.pop("messages", None)
         completion_kwargs["messages"] = messages_list
-        # Avoid global LiteLLM state; use the provider instance's key per request.
-        completion_kwargs["api_key"] = provider.api_key
+        # Avoid global LiteLLM state; use the provider instance's key per request
+        # when that provider authenticates with an API key.
+        api_key = provider.api_key
+        if api_key is not None:
+            completion_kwargs["api_key"] = api_key
 
         try:
             results: list[Any] = batch_completion(**completion_kwargs)  # type: ignore

--- a/models/llm/providers/base.py
+++ b/models/llm/providers/base.py
@@ -32,12 +32,14 @@ class LLMProviderProtocol(ABC):
 
     @property
     @abstractmethod
-    def api_key(self) -> str:
-        """Return the API key for this provider instance.
+    def api_key(self) -> str | None:
+        """Return the API key for this provider instance, if one is needed.
 
         This is used to avoid mutating global LiteLLM state (e.g. litellm.api_key).
-        Providers should store the key on the instance during initialize() and
-        callers should pass api_key=provider.api_key on each LiteLLM call.
+        Providers that use API keys should store the key on the instance during
+        initialize() and callers should pass api_key=provider.api_key on each
+        LiteLLM call. Providers that authenticate outside LiteLLM api_key, such
+        as Bedrock via AWS credentials, should return None.
         """
         ...
 

--- a/models/llm/providers/bedrock_provider.py
+++ b/models/llm/providers/bedrock_provider.py
@@ -1,0 +1,111 @@
+"""Amazon Bedrock provider implementation."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from pydantic import BaseModel
+
+from lib.aws.bedrock import BedrockClient
+from models.llm.config.model_registry import ModelConfigRegistry
+from models.llm.providers.base import LLMProviderProtocol
+
+
+class BedrockProvider(LLMProviderProtocol):
+    """Amazon Bedrock provider for LiteLLM-routed foundation models."""
+
+    MODEL_ID_MAP = {
+        "qwen/qwen3.6-plus": "bedrock/qwen.qwen3-32b-v1:0",
+    }
+
+    def __init__(self) -> None:
+        self._initialized = False
+        self.client: BedrockClient | None = None
+
+    @property
+    def provider_name(self) -> str:
+        return "bedrock"
+
+    @property
+    def supported_models(self) -> list[str]:
+        return ModelConfigRegistry.list_models_for_provider("bedrock")
+
+    @property
+    def api_key(self) -> str | None:
+        return None
+
+    def initialize(self, api_key: str | None = None) -> None:
+        if not self._initialized:
+            self.client = BedrockClient()
+            self._initialized = True
+
+    def supports_model(self, model_name: str) -> bool:
+        return model_name in self.supported_models
+
+    def format_structured_output(
+        self,
+        response_model: type[BaseModel],
+        model_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Format OpenAI-compatible strict JSON schema for LiteLLM."""
+        schema = response_model.model_json_schema()
+        fixed_schema = self._fix_schema_for_strict_mode(schema)
+
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": response_model.__name__.lower(),
+                "strict": True,
+                "schema": fixed_schema,
+            },
+        }
+
+    def prepare_completion_kwargs(
+        self,
+        model: str,
+        messages: list[dict],
+        response_format: dict[str, Any] | None,
+        model_config: dict[str, Any],
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Prepare completion kwargs for LiteLLM Bedrock routing."""
+        if not self._initialized:
+            self.initialize()
+
+        merged_kwargs = {**model_config.get("kwargs", {}), **kwargs}
+
+        completion_kwargs: dict[str, Any] = {
+            "model": self._litellm_model_id(model),
+            "messages": messages,
+            **merged_kwargs,
+        }
+
+        if response_format is not None:
+            completion_kwargs["response_format"] = response_format
+
+        return completion_kwargs
+
+    def _litellm_model_id(self, public_model_id: str) -> str:
+        try:
+            return self.MODEL_ID_MAP[public_model_id]
+        except KeyError as exc:
+            raise ValueError(
+                f"No Bedrock LiteLLM model mapping configured for {public_model_id!r}."
+            ) from exc
+
+    def _fix_schema_for_strict_mode(self, schema: dict[str, Any]) -> dict[str, Any]:
+        """Recursively add additionalProperties: false to all object definitions."""
+        schema_copy = copy.deepcopy(schema)
+        self._patch_recursive(schema_copy)
+        return schema_copy
+
+    def _patch_recursive(self, obj: Any) -> None:
+        if isinstance(obj, dict):
+            if obj.get("type") == "object":
+                obj["additionalProperties"] = False
+            for value in obj.values():
+                self._patch_recursive(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                self._patch_recursive(item)

--- a/models/llm/providers/registry.py
+++ b/models/llm/providers/registry.py
@@ -2,6 +2,7 @@
 
 from models.llm.providers.anthropic_provider import AnthropicProvider
 from models.llm.providers.base import LLMProviderProtocol
+from models.llm.providers.bedrock_provider import BedrockProvider
 from models.llm.providers.openai_provider import OpenAIProvider
 from models.llm.providers.openrouter_provider import OpenRouterProvider
 
@@ -58,3 +59,4 @@ class LLMProviderRegistry:
 LLMProviderRegistry.register(OpenAIProvider)
 LLMProviderRegistry.register(OpenRouterProvider)
 LLMProviderRegistry.register(AnthropicProvider)
+LLMProviderRegistry.register(BedrockProvider)

--- a/tests/models/llm/test_provider_registry.py
+++ b/tests/models/llm/test_provider_registry.py
@@ -1,6 +1,7 @@
 """LLM provider registry routing."""
 
 from models.llm.providers.anthropic_provider import AnthropicProvider
+from models.llm.providers.bedrock_provider import BedrockProvider
 from models.llm.providers.openrouter_provider import OpenRouterProvider
 from models.llm.providers.registry import LLMProviderRegistry
 
@@ -10,6 +11,11 @@ def test_anthropic_claude_sonnet_resolves_to_anthropic_provider() -> None:
     assert isinstance(provider, AnthropicProvider)
 
 
-def test_qwen_resolves_to_openrouter_provider() -> None:
+def test_qwen_resolves_to_bedrock_provider() -> None:
     provider = LLMProviderRegistry.get_provider("qwen/qwen3.6-plus")
+    assert isinstance(provider, BedrockProvider)
+
+
+def test_minimax_resolves_to_openrouter_provider() -> None:
+    provider = LLMProviderRegistry.get_provider("minimax/minimax-m2.5")
     assert isinstance(provider, OpenRouterProvider)


### PR DESCRIPTION
# PR Description

Now that we've gotten AWS Bedrock to work (https://github.com/METResearchGroup/moral_outrage_classifier/pull/38), we move Qwen to AWS Bedrock.

Changes:
- Create wrapper client for AWS Bedrock (`lib/aws/bedrock.py`)
- Create new model provider for AWS Bedrock (`models/llm/providers/bedrock_provider.py`)
- Add Bedrock to the model registry (`models/llm/providers/registry.py`)
- Update model config (`models/llm/config/models.yaml`)

includes also a few more nit changes:
- Update labels to be coerced as ints in `evaluation/run_evaluation_harness.py`
- Make API keys optional, in `models/llm/llm_service.py`

Importantly, the public-facing usage and API doesn't change. Callers can invoke the evaluation harness for Qwen models and the usage doesn't change. For example, `models/llm/smoke_tests/qwen_examples.py` and `evaluation/smoke_tests/model_specific/qwen.py` remain unchanged and still work (but they're much faster).

## Verification

```bash
(base) ➜  moral_outrage_classifier git:(setup-qwen-aws-bedrock) ✗ PYTHONPATH=. uv run python -m evaluation.smoke_tests.model_specific.qwen
Smoke test model alias: qwen
Resolved model id (CSV/metrics key): qwen/qwen3.6-plus
Smoke test output directory (--output-root): /Users/mark/Documents/work/moral_outrage_classifier/evaluation/smoke_tests/outputs/qwen/2026_04_24-23:47:39
Running first eval...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating qwen: 100%|████████████████████████████████████████████████████████████████████| 10/10 [00:10<00:00,  1.04s/it]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                              Evaluation Results                              
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Model             ┃ Accuracy ┃ Precision ┃ Recall ┃ F1     ┃ Total Samples ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ qwen/qwen3.6-plus │ 0.6300   │ 0.5513    │ 0.9556 │ 0.6992 │ 100           │
└───────────────────┴──────────┴───────────┴────────┴────────┴───────────────┘
First run success: all input rows were classified and artifacts/metrics were validated.
Running second eval (dedup check)...
LOADING DATA
DONE LOADING DATA, NOW RUNNING EVALUATION
Evaluating qwen: 0it [00:00, ?it/s]
DONE RUNNING EVALUATION, NOW DISPLAYING RESULTS
                      Evaluation Results                      
┏━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━┳━━━━━━━━━━━━━━━┓
┃ Model ┃ Accuracy ┃ Precision ┃ Recall ┃ F1 ┃ Total Samples ┃
┡━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━╇━━━━━━━━━━━━━━━┩
└───────┴──────────┴───────────┴────────┴────┴───────────────┘
Second run success: deduplication worked and no additional labeling was performed.
Smoke test completed successfully for 'qwen'.
```

Significantly faster than OpenRouter.