### PR TITLE
Fix evaluation harness registry test double

### DIFF
--- a/tests/evaluation/test_run_evaluation_harness.py
+++ b/tests/evaluation/test_run_evaluation_harness.py
@@ -24,7 +24,11 @@ def mock_model() -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def patch_model_registry(mock_model: MagicMock) -> Iterator[None]:
-    with patch.dict("evaluation.run_evaluation_harness.MODEL_REGISTRY", {"perspective_api": MagicMock(return_value=mock_model)}):
+    class FakePerspectiveModel:
+        def batch_classify(self, texts: list[str]) -> list[MagicMock]:
+            return mock_model.batch_classify(texts)
+
+    with patch.dict("evaluation.run_evaluation_harness.MODEL_REGISTRY", {"perspective_api": FakePerspectiveModel}):
         yield
 
 


### PR DESCRIPTION
## Summary
- Update the evaluation harness test registry patch to use a class-shaped fake model.
- Preserve mock delegation so retry and deadletter assertions still validate batch classification calls.

## Test plan
- uv sync --extra test && uv run pytest


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture for model registry mock implementation to enhance test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->