### PR TITLE
Streamlit harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ htmlcov/
 
 *.env
 
+# Streamlit app runtime data
+streamlit_app/uploads/
+streamlit_app/outputs/
+
 # Terraform
 .terraform/
 *.tfstate

--- a/evaluation/column_name_conversion.py
+++ b/evaluation/column_name_conversion.py
@@ -1,0 +1,7 @@
+COLUMN_NAME_CONVERSION: dict[str, list[str]] = {
+    "id": ["id", "tweet_id"],
+    "text": ["text", "body"],
+    "gold_label": ["gold_label", "outrage", "pers_outrage_label"],
+}
+
+REQUIRED_COLUMNS = ("id", "text")

--- a/evaluation/dataloader.py
+++ b/evaluation/dataloader.py
@@ -4,15 +4,10 @@ import math
 from pathlib import Path
 from typing import Any, Iterator
 
+from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION as column_name_conversion
 from evaluation.metadata import get_model_id_value
 from evaluation.model_registry import MODEL_REGISTRY
 from models.llm.models import BaseHarnessLLMModel
-
-column_name_conversion = {
-    "id": ["id", "tweet_id"],
-    "text": ["text", "body"],
-    "gold_label": ["gold_label", "outrage", "pers_outrage_label"],
-}
 
 
 def _normalize_prompt_hash(value: Any) -> str | None:

--- a/evaluation/dataloader.py
+++ b/evaluation/dataloader.py
@@ -199,7 +199,7 @@ class DataLoader:
         gold_label_str = self._get_field_value("gold_label", row)
 
         try:
-            gold_label = int(gold_label_str) if gold_label_str is not None else None
+            gold_label = int(float(gold_label_str)) if gold_label_str is not None else None
         except (ValueError, TypeError):
             gold_label = None
 

--- a/evaluation/run_evaluation_harness.py
+++ b/evaluation/run_evaluation_harness.py
@@ -1,6 +1,7 @@
 import collections
 import csv
 import json
+from collections.abc import Callable
 
 from tenacity import retry, stop_after_attempt, wait_fixed
 from tqdm import tqdm
@@ -123,19 +124,25 @@ class EvaluationHarness:
                     "model": model_name
                 })
 
-    def _run_model_evaluation(self, model_name: str) -> None:
+    def _run_model_evaluation(
+        self,
+        model_name: str,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> None:
         model = MODEL_REGISTRY[model_name]()
         path = self._get_model_output_path(self.new_output_path, model_name)
-        for batch in tqdm(self.dataloaders[model_name], desc=f"Evaluating {model_name}"):
+        dataloader = self.dataloaders[model_name]
+        total_rows = len(dataloader.data)
+        for i, batch in enumerate(tqdm(dataloader, desc=f"Evaluating {model_name}"), start=1):
             texts = [sample["text"] for sample in batch]
-            text_ids = [sample["id"] for sample in batch]
-
             try:
                 self._process_batch(texts, path, model, model_name, batch)
-
             except Exception as e:
                 self._write_to_deadletter_csv(self.new_output_path, model_name, batch)
                 print(f"Error during model evaluation: {e}")
+            if progress_callback:
+                rows_done = min(i * dataloader.batch_size, total_rows)
+                progress_callback(rows_done, total_rows)
                 
     def _copy_model_results_to_merged_csv(self, path: str, writer: csv.DictWriter) -> None:
         """
@@ -205,9 +212,12 @@ class EvaluationHarness:
         with open(metrics_file, "w") as f:
             json.dump(metrics_json, f, indent=2)
 
-    def run_evaluation(self) -> None:
+    def run_evaluation(
+        self,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> None:
         for model in self.models:
-            self._run_model_evaluation(model)
+            self._run_model_evaluation(model, progress_callback=progress_callback)
 
         self._merge_model_results()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ test = [
 examples = [
     "typer>=0.24.1",
 ]
-generic = [
+streamlit = [
     "streamlit>=1.44",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ test = [
 examples = [
     "typer>=0.24.1",
 ]
+generic = [
+    "streamlit>=1.44",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -7,7 +7,7 @@ import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
 
-from constants import (
+from streamlit_app.constants import (
     MODELS,
     RUN_STATE_COMPLETED,
     RUN_STATE_COMPLETED_WITH_FAILURES,
@@ -16,8 +16,8 @@ from constants import (
     RUN_STATE_RUNNING,
 )
 from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION
-from harness_runner import _run_harness
-from utils import (
+from streamlit_app.harness_runner import _run_harness
+from streamlit_app.utils import (
     _count_csv_rows,
     _has_gold_label,
     _read_csv_columns,

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -202,17 +202,25 @@ def _accept_upload(save_path: Path, columns: list[str]) -> None:
     )
 
 
+def _ensure_upload_saved(uploaded_file) -> Path:
+    existing_path: Path | None = st.session_state.dataset_path
+    if existing_path is not None and existing_path.name == uploaded_file.name:
+        return existing_path
+    return save_uploaded_file(uploaded_file)
+
+
 def _render_upload_section(is_running: bool) -> None:
     st.header("1. Upload dataset")
     uploaded_file = st.file_uploader("Upload a CSV file", type=["csv"], disabled=is_running)
-    if uploaded_file is not None:
-        save_path = save_uploaded_file(uploaded_file)
-        columns = read_csv_columns(save_path)
-        missing = validate_columns(columns)
-        if missing:
-            _reject_upload(save_path, missing)
-        else:
-            _accept_upload(save_path, columns)
+    if uploaded_file is None:
+        return
+    save_path = _ensure_upload_saved(uploaded_file)
+    columns = read_csv_columns(save_path)
+    missing = validate_columns(columns)
+    if missing:
+        _reject_upload(save_path, missing)
+    else:
+        _accept_upload(save_path, columns)
 
 
 def _render_model_selection_section(is_running: bool) -> str:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -18,12 +18,12 @@ from streamlit_app.constants import (
 from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION
 from streamlit_app.harness_runner import _run_harness
 from streamlit_app.utils import (
-    _count_csv_rows,
-    _has_gold_label,
-    _read_csv_columns,
-    _save_uploaded_file,
-    _validate_columns,
+    count_csv_rows,
     ensure_dirs,
+    has_gold_label,
+    read_csv_columns,
+    save_uploaded_file,
+    validate_columns,
 )
 
 load_dotenv(Path(__file__).parent.parent / ".env")
@@ -89,7 +89,7 @@ def _finalize_run(result_state: dict) -> None:
     else:
         output_path: Path = result_state["output_path"]
         deadletter_path = output_path / "deadletter.csv"
-        failed_count = _count_csv_rows(deadletter_path) if deadletter_path.exists() else 0
+        failed_count = count_csv_rows(deadletter_path) if deadletter_path.exists() else 0
         st.session_state.result = {
             "output_path": output_path,
             "failed_count": failed_count,
@@ -192,8 +192,8 @@ def _reject_upload(save_path: Path, missing: list[str]) -> None:
 
 
 def _accept_upload(save_path: Path, columns: list[str]) -> None:
-    row_count = _count_csv_rows(save_path)
-    has_gold = _has_gold_label(columns)
+    row_count = count_csv_rows(save_path)
+    has_gold = has_gold_label(columns)
     st.session_state.dataset_path = save_path
     st.session_state.dataset_has_gold = has_gold
     st.caption(
@@ -206,9 +206,9 @@ def _render_upload_section(is_running: bool) -> None:
     st.header("1. Upload dataset")
     uploaded_file = st.file_uploader("Upload a CSV file", type=["csv"], disabled=is_running)
     if uploaded_file is not None:
-        save_path = _save_uploaded_file(uploaded_file)
-        columns = _read_csv_columns(save_path)
-        missing = _validate_columns(columns)
+        save_path = save_uploaded_file(uploaded_file)
+        columns = read_csv_columns(save_path)
+        missing = validate_columns(columns)
         if missing:
             _reject_upload(save_path, missing)
         else:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -190,15 +190,19 @@ def _render_results():
         )
 
 
-def main():
+def _configure_page() -> None:
     st.set_page_config(page_title="Moral Outrage Labeler", layout="centered")
     st.title("Moral Outrage Labeler")
-    _init_session_state()
 
+
+def _get_run_state() -> tuple[str, bool]:
+    _init_session_state()
     run_state = st.session_state.run_state
     is_running = run_state == RUN_STATE_RUNNING
+    return run_state, is_running
 
-    # ── Upload dataset ─────────────────────────────────────────────────────────
+
+def _render_upload_section(is_running: bool) -> None:
     st.header("1. Upload dataset")
     uploaded_file = st.file_uploader("Upload a CSV file", type=["csv"], disabled=is_running)
     if uploaded_file is not None:
@@ -225,37 +229,50 @@ def main():
                 + (" · gold_label present — evaluation metrics will be shown" if has_gold else "")
             )
 
-    dataset_path: Path | None = st.session_state.dataset_path
 
-    # ── Select model ───────────────────────────────────────────────────────────
+def _render_model_selection_section(is_running: bool) -> str:
     st.header("2. Select model")
-    selected_model = st.selectbox("Model", MODELS, disabled=is_running)
+    return st.selectbox("Model", MODELS, disabled=is_running)
 
-    # ── Run ────────────────────────────────────────────────────────────────────
+
+def _render_run_section(is_running: bool, dataset_path: Path | None, selected_model: str) -> None:
     st.header("3. Run")
     if st.button("Start labeling", disabled=is_running or dataset_path is None):
         _start_run(dataset_path, selected_model)
         st.rerun()
-
     if dataset_path is None and not is_running:
         st.caption("Upload a dataset above to enable the run.")
 
-    # ── Progress ───────────────────────────────────────────────────────────────
-    if is_running:
-        st.header("Running")
-        _poll_running_state()
-        return
 
-    # ── Results ────────────────────────────────────────────────────────────────
+def _render_progress_section() -> None:
+    st.header("Running")
+    _poll_running_state()
+
+
+def _render_results_section(run_state: str) -> None:
     if run_state in (RUN_STATE_COMPLETED, RUN_STATE_COMPLETED_WITH_FAILURES):
         st.header("Results")
         _render_results()
-
     elif run_state == RUN_STATE_FAILED:
         st.error(f"Run failed: {st.session_state.run_error}")
         if st.button("Reset"):
             st.session_state.run_state = RUN_STATE_READY
             st.rerun()
+
+
+def main():
+    _configure_page()
+    run_state, is_running = _get_run_state()
+
+    _render_upload_section(is_running)
+    selected_model = _render_model_selection_section(is_running)
+    _render_run_section(is_running, st.session_state.dataset_path, selected_model)
+
+    if is_running:
+        _render_progress_section()
+        return
+
+    _render_results_section(run_state)
 
 
 if __name__ == "__main__":

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import threading
 import time
 from pathlib import Path

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import sys
 import threading
@@ -11,27 +10,25 @@ from dotenv import load_dotenv
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
-from evaluation.model_registry import MODEL_REGISTRY
-from evaluation.run_evaluation_harness import EvaluationHarness
-from lib.timestamp_utils import get_current_timestamp
+from constants import (
+    MODELS,
+    RUN_STATE_COMPLETED,
+    RUN_STATE_COMPLETED_WITH_FAILURES,
+    RUN_STATE_FAILED,
+    RUN_STATE_READY,
+    RUN_STATE_RUNNING,
+)
+from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION
+from harness_runner import _run_harness
+from utils import (
+    _count_csv_rows,
+    _has_gold_label,
+    _read_csv_columns,
+    _save_uploaded_file,
+    _validate_columns,
+)
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-_env_path = PROJECT_ROOT / ".env"
-load_dotenv(_env_path)
-
-UPLOADS_DIR = PROJECT_ROOT / "streamlit_app" / "uploads"
-OUTPUTS_DIR = PROJECT_ROOT / "streamlit_app" / "outputs"
-UPLOADS_DIR.mkdir(exist_ok=True)
-OUTPUTS_DIR.mkdir(exist_ok=True)
-
-MODELS = list(MODEL_REGISTRY.keys())
-
-RUN_STATE_READY = "ready"
-RUN_STATE_RUNNING = "running"
-RUN_STATE_COMPLETED = "completed"
-RUN_STATE_COMPLETED_WITH_FAILURES = "completed_with_failures"
-RUN_STATE_FAILED = "failed"
+load_dotenv(Path(__file__).parent.parent / ".env")
 
 
 def _init_session_state():
@@ -48,55 +45,6 @@ def _init_session_state():
     for key, val in defaults.items():
         if key not in st.session_state:
             st.session_state[key] = val
-
-
-def _validate_columns(columns: list[str]) -> list[str]:
-    """Return canonical names of required fields that are missing from columns."""
-    missing = []
-    for canonical in REQUIRED_COLUMNS:
-        aliases = COLUMN_NAME_CONVERSION[canonical]
-        if not any(alias in columns for alias in aliases):
-            missing.append(canonical)
-    return missing
-
-
-def _has_gold_label(columns: list[str]) -> bool:
-    return any(alias in columns for alias in COLUMN_NAME_CONVERSION["gold_label"])
-
-
-def _read_csv_columns(path: Path) -> list[str]:
-    with open(path, newline="") as f:
-        reader = csv.DictReader(f)
-        return list(reader.fieldnames or [])
-
-
-def _count_csv_rows(path: Path) -> int:
-    with open(path, newline="") as f:
-        return sum(1 for _ in csv.DictReader(f))
-
-
-def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict):
-    timestamp = get_current_timestamp()
-    harness = EvaluationHarness(
-        input_path=str(dataset_path.relative_to(PROJECT_ROOT)),
-        output_path=str(OUTPUTS_DIR.relative_to(PROJECT_ROOT)),
-        batch_size=10,
-        models=[model],
-        timestamp=timestamp,
-    )
-    harness.load_data()
-
-    def callback(current: int, total: int):
-        progress_state["current"] = current
-        progress_state["total"] = total
-
-    try:
-        harness.run_evaluation(progress_callback=callback)
-        result_state["output_path"] = PROJECT_ROOT / "streamlit_app" / "outputs" / timestamp
-        result_state["done"] = True
-    except Exception as e:
-        result_state["error"] = str(e)
-        result_state["done"] = True
 
 
 def _start_run(dataset_path: Path, model: str):
@@ -210,10 +158,8 @@ def _render_output_preview(output_csv: Path) -> None:
 
 def _render_results():
     output_csv, metrics_path, failed_count = _unpack_run_result()
-
     _render_completion_status(failed_count)
     _render_output_preview(output_csv)
-
     _render_evaluation_metrics(metrics_path)
     _render_export_button(output_csv)
 
@@ -224,16 +170,9 @@ def _configure_page() -> None:
 
 
 def _get_run_state() -> tuple[str, bool]:
-    _init_session_state()
     run_state = st.session_state.run_state
     is_running = run_state == RUN_STATE_RUNNING
     return run_state, is_running
-
-
-def _save_uploaded_file(uploaded_file) -> Path:
-    save_path = UPLOADS_DIR / uploaded_file.name
-    save_path.write_bytes(uploaded_file.read())
-    return save_path
 
 
 def _reject_upload(save_path: Path, missing: list[str]) -> None:
@@ -302,6 +241,7 @@ def _render_results_section(run_state: str) -> None:
 
 def main():
     _configure_page()
+    _init_session_state()
     run_state, is_running = _get_run_state()
 
     _render_upload_section(is_running)

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,0 +1,262 @@
+import csv
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
+from evaluation.model_registry import MODEL_REGISTRY
+from evaluation.run_evaluation_harness import EvaluationHarness
+from lib.timestamp_utils import get_current_timestamp
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_env_path = PROJECT_ROOT / ".env"
+load_dotenv(_env_path)
+
+UPLOADS_DIR = PROJECT_ROOT / "streamlit_app" / "uploads"
+OUTPUTS_DIR = PROJECT_ROOT / "streamlit_app" / "outputs"
+UPLOADS_DIR.mkdir(exist_ok=True)
+OUTPUTS_DIR.mkdir(exist_ok=True)
+
+MODELS = list(MODEL_REGISTRY.keys())
+
+RUN_STATE_READY = "ready"
+RUN_STATE_RUNNING = "running"
+RUN_STATE_COMPLETED = "completed"
+RUN_STATE_COMPLETED_WITH_FAILURES = "completed_with_failures"
+RUN_STATE_FAILED = "failed"
+
+
+def _init_session_state():
+    defaults = {
+        "run_state": RUN_STATE_READY,
+        "run_thread": None,
+        "progress": {"current": 0, "total": 0},
+        "_result_state": None,
+        "result": None,
+        "run_error": None,
+        "dataset_path": None,
+        "dataset_has_gold": False,
+    }
+    for key, val in defaults.items():
+        if key not in st.session_state:
+            st.session_state[key] = val
+
+
+def _validate_columns(columns: list[str]) -> list[str]:
+    """Return canonical names of required fields that are missing from columns."""
+    missing = []
+    for canonical in REQUIRED_COLUMNS:
+        aliases = COLUMN_NAME_CONVERSION[canonical]
+        if not any(alias in columns for alias in aliases):
+            missing.append(canonical)
+    return missing
+
+
+def _has_gold_label(columns: list[str]) -> bool:
+    return any(alias in columns for alias in COLUMN_NAME_CONVERSION["gold_label"])
+
+
+def _read_csv_columns(path: Path) -> list[str]:
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader.fieldnames or [])
+
+
+def _count_csv_rows(path: Path) -> int:
+    with open(path, newline="") as f:
+        return sum(1 for _ in csv.DictReader(f))
+
+
+def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict):
+    timestamp = get_current_timestamp()
+    harness = EvaluationHarness(
+        input_path=str(dataset_path.relative_to(PROJECT_ROOT)),
+        output_path=str(OUTPUTS_DIR.relative_to(PROJECT_ROOT)),
+        batch_size=10,
+        models=[model],
+        timestamp=timestamp,
+    )
+    harness.load_data()
+
+    def callback(current: int, total: int):
+        progress_state["current"] = current
+        progress_state["total"] = total
+
+    try:
+        harness.run_evaluation(progress_callback=callback)
+        result_state["output_path"] = PROJECT_ROOT / "streamlit_app" / "outputs" / timestamp
+        result_state["done"] = True
+    except Exception as e:
+        result_state["error"] = str(e)
+        result_state["done"] = True
+
+
+def _start_run(dataset_path: Path, model: str):
+    progress_state = {"current": 0, "total": 0}
+    result_state = {"done": False, "error": None, "output_path": None}
+
+    st.session_state.progress = progress_state
+    st.session_state._result_state = result_state
+    st.session_state.run_state = RUN_STATE_RUNNING
+    st.session_state.result = None
+    st.session_state.run_error = None
+
+    thread = threading.Thread(
+        target=_run_harness,
+        args=(dataset_path, model, progress_state, result_state),
+        daemon=True,
+    )
+    st.session_state.run_thread = thread
+    thread.start()
+
+
+def _poll_running_state():
+    thread: threading.Thread = st.session_state.run_thread
+    result_state: dict = st.session_state._result_state
+
+    if thread and thread.is_alive():
+        current = st.session_state.progress["current"]
+        total = st.session_state.progress["total"]
+        if total > 0:
+            st.progress(current / total, text=f"{current:,} / {total:,} rows")
+        else:
+            st.progress(0.0, text="Starting…")
+        time.sleep(0.5)
+        st.rerun()
+    else:
+        if result_state.get("error"):
+            st.session_state.run_state = RUN_STATE_FAILED
+            st.session_state.run_error = result_state["error"]
+        else:
+            output_path: Path = result_state["output_path"]
+            deadletter_path = output_path / "deadletter.csv"
+            failed_count = _count_csv_rows(deadletter_path) if deadletter_path.exists() else 0
+            st.session_state.result = {
+                "output_path": output_path,
+                "failed_count": failed_count,
+            }
+            st.session_state.run_state = (
+                RUN_STATE_COMPLETED_WITH_FAILURES if failed_count > 0 else RUN_STATE_COMPLETED
+            )
+        st.rerun()
+
+
+def _render_results():
+    result = st.session_state.result
+    output_path: Path = result["output_path"]
+    failed_count: int = result["failed_count"]
+    output_csv = output_path / "output.csv"
+    metrics_path = output_path / "metrics.json"
+
+    if st.session_state.run_state == RUN_STATE_COMPLETED:
+        st.success("Labeling complete.")
+    else:
+        st.warning(
+            f"Labeling complete with **{failed_count}** failed row(s). "
+            "Export the output below, then rerun the dataset to recover failed rows."
+        )
+
+    st.subheader("Output preview")
+    df = pd.read_csv(output_csv)
+    st.dataframe(df.head(50), width="stretch")
+
+    if metrics_path.exists() and st.session_state.dataset_has_gold:
+        st.subheader("Evaluation metrics")
+        with open(metrics_path) as f:
+            metrics = json.load(f)
+        for model_name, m in metrics.items():
+            st.write(f"**{model_name}**")
+            cols = st.columns(4)
+            cols[0].metric("Accuracy", f"{m['accuracy']:.4f}")
+            cols[1].metric("Precision", f"{m['precision']:.4f}")
+            cols[2].metric("Recall", f"{m['recall']:.4f}")
+            cols[3].metric("F1", f"{m['f1_score']:.4f}")
+            st.caption(f"Evaluated on {m['total_samples']} samples")
+
+    with open(output_csv, "rb") as f:
+        st.download_button(
+            label="Export output CSV",
+            data=f,
+            file_name="labeled_output.csv",
+            mime="text/csv",
+        )
+
+
+def main():
+    st.set_page_config(page_title="Moral Outrage Labeler", layout="centered")
+    st.title("Moral Outrage Labeler")
+    _init_session_state()
+
+    run_state = st.session_state.run_state
+    is_running = run_state == RUN_STATE_RUNNING
+
+    # ── Upload dataset ─────────────────────────────────────────────────────────
+    st.header("1. Upload dataset")
+    uploaded_file = st.file_uploader("Upload a CSV file", type=["csv"], disabled=is_running)
+    if uploaded_file is not None:
+        save_path = UPLOADS_DIR / uploaded_file.name
+        content = uploaded_file.read()
+        save_path.write_bytes(content)
+        columns = _read_csv_columns(save_path)
+        missing = _validate_columns(columns)
+        if missing:
+            save_path.unlink(missing_ok=True)
+            aliases = {c: COLUMN_NAME_CONVERSION[c] for c in missing}
+            st.error(
+                f"Upload rejected — required field(s) not found: "
+                + ", ".join(f"`{c}` (accepted names: {aliases[c]})" for c in missing)
+            )
+            st.session_state.dataset_path = None
+        else:
+            row_count = _count_csv_rows(save_path)
+            has_gold = _has_gold_label(columns)
+            st.session_state.dataset_path = save_path
+            st.session_state.dataset_has_gold = has_gold
+            st.caption(
+                f"{row_count} rows · columns: {', '.join(columns)}"
+                + (" · gold_label present — evaluation metrics will be shown" if has_gold else "")
+            )
+
+    dataset_path: Path | None = st.session_state.dataset_path
+
+    # ── Select model ───────────────────────────────────────────────────────────
+    st.header("2. Select model")
+    selected_model = st.selectbox("Model", MODELS, disabled=is_running)
+
+    # ── Run ────────────────────────────────────────────────────────────────────
+    st.header("3. Run")
+    if st.button("Start labeling", disabled=is_running or dataset_path is None):
+        _start_run(dataset_path, selected_model)
+        st.rerun()
+
+    if dataset_path is None and not is_running:
+        st.caption("Upload a dataset above to enable the run.")
+
+    # ── Progress ───────────────────────────────────────────────────────────────
+    if is_running:
+        st.header("Running")
+        _poll_running_state()
+        return
+
+    # ── Results ────────────────────────────────────────────────────────────────
+    if run_state in (RUN_STATE_COMPLETED, RUN_STATE_COMPLETED_WITH_FAILURES):
+        st.header("Results")
+        _render_results()
+
+    elif run_state == RUN_STATE_FAILED:
+        st.error(f"Run failed: {st.session_state.run_error}")
+        if st.button("Reset"):
+            st.session_state.run_state = RUN_STATE_READY
+            st.rerun()
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -118,44 +118,55 @@ def _start_run(dataset_path: Path, model: str):
     thread.start()
 
 
+def _render_progress_bar() -> None:
+    current = st.session_state.progress["current"]
+    total = st.session_state.progress["total"]
+    if total > 0:
+        st.progress(current / total, text=f"{current:,} / {total:,} rows")
+    else:
+        st.progress(0.0, text="Starting…")
+    time.sleep(0.5)
+    st.rerun()
+
+
+def _finalize_run(result_state: dict) -> None:
+    if result_state.get("error"):
+        st.session_state.run_state = RUN_STATE_FAILED
+        st.session_state.run_error = result_state["error"]
+    else:
+        output_path: Path = result_state["output_path"]
+        deadletter_path = output_path / "deadletter.csv"
+        failed_count = _count_csv_rows(deadletter_path) if deadletter_path.exists() else 0
+        st.session_state.result = {
+            "output_path": output_path,
+            "failed_count": failed_count,
+        }
+        st.session_state.run_state = (
+            RUN_STATE_COMPLETED_WITH_FAILURES if failed_count > 0 else RUN_STATE_COMPLETED
+        )
+    st.rerun()
+
+
 def _poll_running_state():
     thread: threading.Thread = st.session_state.run_thread
     result_state: dict = st.session_state._result_state
 
     if thread and thread.is_alive():
-        current = st.session_state.progress["current"]
-        total = st.session_state.progress["total"]
-        if total > 0:
-            st.progress(current / total, text=f"{current:,} / {total:,} rows")
-        else:
-            st.progress(0.0, text="Starting…")
-        time.sleep(0.5)
-        st.rerun()
+        _render_progress_bar()
     else:
-        if result_state.get("error"):
-            st.session_state.run_state = RUN_STATE_FAILED
-            st.session_state.run_error = result_state["error"]
-        else:
-            output_path: Path = result_state["output_path"]
-            deadletter_path = output_path / "deadletter.csv"
-            failed_count = _count_csv_rows(deadletter_path) if deadletter_path.exists() else 0
-            st.session_state.result = {
-                "output_path": output_path,
-                "failed_count": failed_count,
-            }
-            st.session_state.run_state = (
-                RUN_STATE_COMPLETED_WITH_FAILURES if failed_count > 0 else RUN_STATE_COMPLETED
-            )
-        st.rerun()
+        _finalize_run(result_state)
 
 
-def _render_results():
+def _unpack_run_result() -> tuple[Path, Path, int]:
     result = st.session_state.result
     output_path: Path = result["output_path"]
     failed_count: int = result["failed_count"]
     output_csv = output_path / "output.csv"
     metrics_path = output_path / "metrics.json"
+    return output_csv, metrics_path, failed_count
 
+
+def _render_completion_status(failed_count: int) -> None:
     if st.session_state.run_state == RUN_STATE_COMPLETED:
         st.success("Labeling complete.")
     else:
@@ -164,23 +175,24 @@ def _render_results():
             "Export the output below, then rerun the dataset to recover failed rows."
         )
 
-    st.subheader("Output preview")
-    df = pd.read_csv(output_csv)
-    st.dataframe(df.head(50), width="stretch")
 
-    if metrics_path.exists() and st.session_state.dataset_has_gold:
-        st.subheader("Evaluation metrics")
-        with open(metrics_path) as f:
-            metrics = json.load(f)
-        for model_name, m in metrics.items():
-            st.write(f"**{model_name}**")
-            cols = st.columns(4)
-            cols[0].metric("Accuracy", f"{m['accuracy']:.4f}")
-            cols[1].metric("Precision", f"{m['precision']:.4f}")
-            cols[2].metric("Recall", f"{m['recall']:.4f}")
-            cols[3].metric("F1", f"{m['f1_score']:.4f}")
-            st.caption(f"Evaluated on {m['total_samples']} samples")
+def _render_evaluation_metrics(metrics_path: Path) -> None:
+    if not (metrics_path.exists() and st.session_state.dataset_has_gold):
+        return
+    st.subheader("Evaluation metrics")
+    with open(metrics_path) as f:
+        metrics = json.load(f)
+    for model_name, m in metrics.items():
+        st.write(f"**{model_name}**")
+        cols = st.columns(4)
+        cols[0].metric("Accuracy", f"{m['accuracy']:.4f}")
+        cols[1].metric("Precision", f"{m['precision']:.4f}")
+        cols[2].metric("Recall", f"{m['recall']:.4f}")
+        cols[3].metric("F1", f"{m['f1_score']:.4f}")
+        st.caption(f"Evaluated on {m['total_samples']} samples")
 
+
+def _render_export_button(output_csv: Path) -> None:
     with open(output_csv, "rb") as f:
         st.download_button(
             label="Export output CSV",
@@ -188,6 +200,22 @@ def _render_results():
             file_name="labeled_output.csv",
             mime="text/csv",
         )
+
+
+def _render_output_preview(output_csv: Path) -> None:
+    st.subheader("Output preview")
+    df = pd.read_csv(output_csv)
+    st.dataframe(df.head(50), width="stretch")
+
+
+def _render_results():
+    output_csv, metrics_path, failed_count = _unpack_run_result()
+
+    _render_completion_status(failed_count)
+    _render_output_preview(output_csv)
+
+    _render_evaluation_metrics(metrics_path)
+    _render_export_button(output_csv)
 
 
 def _configure_page() -> None:
@@ -202,32 +230,44 @@ def _get_run_state() -> tuple[str, bool]:
     return run_state, is_running
 
 
+def _save_uploaded_file(uploaded_file) -> Path:
+    save_path = UPLOADS_DIR / uploaded_file.name
+    save_path.write_bytes(uploaded_file.read())
+    return save_path
+
+
+def _reject_upload(save_path: Path, missing: list[str]) -> None:
+    save_path.unlink(missing_ok=True)
+    aliases = {c: COLUMN_NAME_CONVERSION[c] for c in missing}
+    st.error(
+        f"Upload rejected — required field(s) not found: "
+        + ", ".join(f"`{c}` (accepted names: {aliases[c]})" for c in missing)
+    )
+    st.session_state.dataset_path = None
+
+
+def _accept_upload(save_path: Path, columns: list[str]) -> None:
+    row_count = _count_csv_rows(save_path)
+    has_gold = _has_gold_label(columns)
+    st.session_state.dataset_path = save_path
+    st.session_state.dataset_has_gold = has_gold
+    st.caption(
+        f"{row_count} rows · columns: {', '.join(columns)}"
+        + (" · gold_label present — evaluation metrics will be shown" if has_gold else "")
+    )
+
+
 def _render_upload_section(is_running: bool) -> None:
     st.header("1. Upload dataset")
     uploaded_file = st.file_uploader("Upload a CSV file", type=["csv"], disabled=is_running)
     if uploaded_file is not None:
-        save_path = UPLOADS_DIR / uploaded_file.name
-        content = uploaded_file.read()
-        save_path.write_bytes(content)
+        save_path = _save_uploaded_file(uploaded_file)
         columns = _read_csv_columns(save_path)
         missing = _validate_columns(columns)
         if missing:
-            save_path.unlink(missing_ok=True)
-            aliases = {c: COLUMN_NAME_CONVERSION[c] for c in missing}
-            st.error(
-                f"Upload rejected — required field(s) not found: "
-                + ", ".join(f"`{c}` (accepted names: {aliases[c]})" for c in missing)
-            )
-            st.session_state.dataset_path = None
+            _reject_upload(save_path, missing)
         else:
-            row_count = _count_csv_rows(save_path)
-            has_gold = _has_gold_label(columns)
-            st.session_state.dataset_path = save_path
-            st.session_state.dataset_has_gold = has_gold
-            st.caption(
-                f"{row_count} rows · columns: {', '.join(columns)}"
-                + (" · gold_label present — evaluation metrics will be shown" if has_gold else "")
-            )
+            _accept_upload(save_path, columns)
 
 
 def _render_model_selection_section(is_running: bool) -> str:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -23,12 +23,14 @@ from streamlit_app.utils import (
     _read_csv_columns,
     _save_uploaded_file,
     _validate_columns,
+    ensure_dirs,
 )
 
 load_dotenv(Path(__file__).parent.parent / ".env")
 
 
 def _init_session_state():
+    ensure_dirs()
     defaults = {
         "run_state": RUN_STATE_READY,
         "run_thread": None,

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -8,8 +8,6 @@ import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from constants import (
     MODELS,
     RUN_STATE_COMPLETED,
@@ -48,18 +46,22 @@ def _init_session_state():
 
 
 def _start_run(dataset_path: Path, model: str):
+    state_lock = threading.Lock()
+
     progress_state = {"current": 0, "total": 0}
     result_state = {"done": False, "error": None, "output_path": None}
 
-    st.session_state.progress = progress_state
-    st.session_state._result_state = result_state
-    st.session_state.run_state = RUN_STATE_RUNNING
-    st.session_state.result = None
-    st.session_state.run_error = None
+    with state_lock:
+        st.session_state.state_lock = state_lock
+        st.session_state.progress = progress_state
+        st.session_state._result_state = result_state
+        st.session_state.run_state = RUN_STATE_RUNNING
+        st.session_state.result = None
+        st.session_state.run_error = None
 
     thread = threading.Thread(
         target=_run_harness,
-        args=(dataset_path, model, progress_state, result_state),
+        args=(dataset_path, model, progress_state, result_state, state_lock),
         daemon=True,
     )
     st.session_state.run_thread = thread
@@ -67,8 +69,10 @@ def _start_run(dataset_path: Path, model: str):
 
 
 def _render_progress_bar() -> None:
-    current = st.session_state.progress["current"]
-    total = st.session_state.progress["total"]
+    with st.session_state.state_lock:
+        current = st.session_state.progress["current"]
+        total = st.session_state.progress["total"]
+
     if total > 0:
         st.progress(current / total, text=f"{current:,} / {total:,} rows")
     else:
@@ -97,11 +101,12 @@ def _finalize_run(result_state: dict) -> None:
 
 def _poll_running_state():
     thread: threading.Thread = st.session_state.run_thread
-    result_state: dict = st.session_state._result_state
 
     if thread and thread.is_alive():
         _render_progress_bar()
     else:
+        with st.session_state.state_lock:
+            result_state: dict = st.session_state._result_state
         _finalize_run(result_state)
 
 

--- a/streamlit_app/constants.py
+++ b/streamlit_app/constants.py
@@ -5,8 +5,6 @@ from evaluation.model_registry import MODEL_REGISTRY
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 UPLOADS_DIR = PROJECT_ROOT / "streamlit_app" / "uploads"
 OUTPUTS_DIR = PROJECT_ROOT / "streamlit_app" / "outputs"
-UPLOADS_DIR.mkdir(exist_ok=True)
-OUTPUTS_DIR.mkdir(exist_ok=True)
 
 MODELS = list(MODEL_REGISTRY.keys())
 
@@ -15,3 +13,4 @@ RUN_STATE_RUNNING = "running"
 RUN_STATE_COMPLETED = "completed"
 RUN_STATE_COMPLETED_WITH_FAILURES = "completed_with_failures"
 RUN_STATE_FAILED = "failed"
+

--- a/streamlit_app/constants.py
+++ b/streamlit_app/constants.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from evaluation.model_registry import MODEL_REGISTRY
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+UPLOADS_DIR = PROJECT_ROOT / "streamlit_app" / "uploads"
+OUTPUTS_DIR = PROJECT_ROOT / "streamlit_app" / "outputs"
+UPLOADS_DIR.mkdir(exist_ok=True)
+OUTPUTS_DIR.mkdir(exist_ok=True)
+
+MODELS = list(MODEL_REGISTRY.keys())
+
+RUN_STATE_READY = "ready"
+RUN_STATE_RUNNING = "running"
+RUN_STATE_COMPLETED = "completed"
+RUN_STATE_COMPLETED_WITH_FAILURES = "completed_with_failures"
+RUN_STATE_FAILED = "failed"

--- a/streamlit_app/constants.py
+++ b/streamlit_app/constants.py
@@ -1,7 +1,4 @@
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from evaluation.model_registry import MODEL_REGISTRY
 

--- a/streamlit_app/harness_runner.py
+++ b/streamlit_app/harness_runner.py
@@ -8,7 +8,7 @@ from lib.timestamp_utils import get_current_timestamp
 from constants import PROJECT_ROOT, OUTPUTS_DIR
 
 
-def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict):
+def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict, state_lock):
     timestamp = get_current_timestamp()
     harness = EvaluationHarness(
         input_path=str(dataset_path.relative_to(PROJECT_ROOT)),
@@ -20,13 +20,17 @@ def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_st
     harness.load_data()
 
     def callback(current: int, total: int):
-        progress_state["current"] = current
-        progress_state["total"] = total
+        with state_lock:
+            progress_state["current"] = current
+            progress_state["total"] = total
 
     try:
         harness.run_evaluation(progress_callback=callback)
-        result_state["output_path"] = OUTPUTS_DIR / timestamp
-        result_state["done"] = True
+        with state_lock:
+            result_state["output_path"] = OUTPUTS_DIR / timestamp
     except Exception as e:
-        result_state["error"] = str(e)
-        result_state["done"] = True
+        with state_lock:
+            result_state["error"] = str(e)
+    finally:
+        with state_lock:
+            result_state["done"] = True

--- a/streamlit_app/harness_runner.py
+++ b/streamlit_app/harness_runner.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from evaluation.run_evaluation_harness import EvaluationHarness
+from lib.timestamp_utils import get_current_timestamp
+from constants import PROJECT_ROOT, OUTPUTS_DIR
+
+
+def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict):
+    timestamp = get_current_timestamp()
+    harness = EvaluationHarness(
+        input_path=str(dataset_path.relative_to(PROJECT_ROOT)),
+        output_path=str(OUTPUTS_DIR.relative_to(PROJECT_ROOT)),
+        batch_size=10,
+        models=[model],
+        timestamp=timestamp,
+    )
+    harness.load_data()
+
+    def callback(current: int, total: int):
+        progress_state["current"] = current
+        progress_state["total"] = total
+
+    try:
+        harness.run_evaluation(progress_callback=callback)
+        result_state["output_path"] = OUTPUTS_DIR / timestamp
+        result_state["done"] = True
+    except Exception as e:
+        result_state["error"] = str(e)
+        result_state["done"] = True

--- a/streamlit_app/harness_runner.py
+++ b/streamlit_app/harness_runner.py
@@ -1,7 +1,4 @@
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from evaluation.run_evaluation_harness import EvaluationHarness
 from lib.timestamp_utils import get_current_timestamp

--- a/streamlit_app/harness_runner.py
+++ b/streamlit_app/harness_runner.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from evaluation.run_evaluation_harness import EvaluationHarness
 from lib.timestamp_utils import get_current_timestamp
-from constants import PROJECT_ROOT, OUTPUTS_DIR
+from streamlit_app.constants import PROJECT_ROOT, OUTPUTS_DIR
 
 
 def _run_harness(dataset_path: Path, model: str, progress_state: dict, result_state: dict, state_lock):

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -2,7 +2,7 @@ import csv
 from pathlib import Path
 
 from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
-from constants import UPLOADS_DIR
+from streamlit_app.constants import UPLOADS_DIR
 
 
 def _validate_columns(columns: list[str]) -> list[str]:

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -1,0 +1,38 @@
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
+from constants import UPLOADS_DIR
+
+
+def _validate_columns(columns: list[str]) -> list[str]:
+    missing = []
+    for canonical in REQUIRED_COLUMNS:
+        aliases = COLUMN_NAME_CONVERSION[canonical]
+        if not any(alias in columns for alias in aliases):
+            missing.append(canonical)
+    return missing
+
+
+def _has_gold_label(columns: list[str]) -> bool:
+    return any(alias in columns for alias in COLUMN_NAME_CONVERSION["gold_label"])
+
+
+def _read_csv_columns(path: Path) -> list[str]:
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader.fieldnames or [])
+
+
+def _count_csv_rows(path: Path) -> int:
+    with open(path, newline="") as f:
+        return sum(1 for _ in csv.DictReader(f))
+
+
+def _save_uploaded_file(uploaded_file) -> Path:
+    save_path = UPLOADS_DIR / uploaded_file.name
+    save_path.write_bytes(uploaded_file.read())
+    return save_path

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -1,8 +1,5 @@
 import csv
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
 from constants import UPLOADS_DIR

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -2,7 +2,7 @@ import csv
 from pathlib import Path
 
 from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_COLUMNS
-from streamlit_app.constants import UPLOADS_DIR
+from streamlit_app.constants import OUTPUTS_DIR, UPLOADS_DIR
 
 
 def _validate_columns(columns: list[str]) -> list[str]:
@@ -27,6 +27,11 @@ def _read_csv_columns(path: Path) -> list[str]:
 def _count_csv_rows(path: Path) -> int:
     with open(path, newline="") as f:
         return sum(1 for _ in csv.DictReader(f))
+
+
+def ensure_dirs() -> None:
+    UPLOADS_DIR.mkdir(exist_ok=True)
+    OUTPUTS_DIR.mkdir(exist_ok=True)
 
 
 def _save_uploaded_file(uploaded_file) -> Path:

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -5,7 +5,7 @@ from evaluation.column_name_conversion import COLUMN_NAME_CONVERSION, REQUIRED_C
 from streamlit_app.constants import OUTPUTS_DIR, UPLOADS_DIR
 
 
-def _validate_columns(columns: list[str]) -> list[str]:
+def validate_columns(columns: list[str]) -> list[str]:
     missing = []
     for canonical in REQUIRED_COLUMNS:
         aliases = COLUMN_NAME_CONVERSION[canonical]
@@ -14,17 +14,17 @@ def _validate_columns(columns: list[str]) -> list[str]:
     return missing
 
 
-def _has_gold_label(columns: list[str]) -> bool:
+def has_gold_label(columns: list[str]) -> bool:
     return any(alias in columns for alias in COLUMN_NAME_CONVERSION["gold_label"])
 
 
-def _read_csv_columns(path: Path) -> list[str]:
+def read_csv_columns(path: Path) -> list[str]:
     with open(path, newline="") as f:
         reader = csv.DictReader(f)
         return list(reader.fieldnames or [])
 
 
-def _count_csv_rows(path: Path) -> int:
+def count_csv_rows(path: Path) -> int:
     with open(path, newline="") as f:
         return sum(1 for _ in csv.DictReader(f))
 
@@ -34,7 +34,7 @@ def ensure_dirs() -> None:
     OUTPUTS_DIR.mkdir(exist_ok=True)
 
 
-def _save_uploaded_file(uploaded_file) -> Path:
+def save_uploaded_file(uploaded_file) -> Path:
     save_path = UPLOADS_DIR / uploaded_file.name
     save_path.write_bytes(uploaded_file.read())
     return save_path

--- a/tests/evaluation/test_run_evaluation_harness.py
+++ b/tests/evaluation/test_run_evaluation_harness.py
@@ -12,6 +12,19 @@ FAKE_BATCH: list[dict[str, str]] = [
 ]
 
 
+class FakeDataLoader:
+    def __init__(self, batches: list[list[dict]], batch_size: int = 2):
+        self.data = [row for batch in batches for row in batch]
+        self.batch_size = batch_size
+        self._batches = batches
+
+    def __iter__(self):
+        return iter(self._batches)
+
+    def __len__(self):
+        return len(self._batches)
+
+
 @pytest.fixture
 def mock_model() -> MagicMock:
     mm = MagicMock()
@@ -43,7 +56,7 @@ def harness(tmp_path: Path) -> EvaluationHarness:
             timestamp="test_run",
         )
 
-    h.dataloaders["perspective_api"] = [FAKE_BATCH]  # type: ignore[assignment]
+    h.dataloaders["perspective_api"] = FakeDataLoader([FAKE_BATCH])
     return h
 
 
@@ -70,7 +83,7 @@ class TestDeadletter:
     def test_deadletter_appends_across_multiple_failed_batches(self, harness: EvaluationHarness) -> None:
         batch1: list[dict[str, str]] = [{"id": "1", "text": "a", "gold_label": "1"}]
         batch2: list[dict[str, str]] = [{"id": "2", "text": "b", "gold_label": "0"}]
-        harness.dataloaders["perspective_api"] = [batch1, batch2]  # type: ignore[assignment]
+        harness.dataloaders["perspective_api"] = FakeDataLoader([batch1, batch2])
 
         with patch.object(harness, "_process_batch", side_effect=Exception("fail")):
             harness._run_model_evaluation("perspective_api")


### PR DESCRIPTION
**Problem**
Want to see if our harness can be used as a generic app.

Fixes #36 

**Solution**
Build a simple UI with streamlit that interfaces a generic evaluation harness. 

**State (after)**:
<img width="1245" height="812" alt="image" src="https://github.com/user-attachments/assets/e718bc74-cb72-4976-b9f6-de642b1ea640" />

**Changes**:
1. Bug Fix: in `evaluation/dataloader.py` cast dataset label to float first before int to accommodate for perspective dataset. 
```
int("1")    # 1 ✓                                                                                                                                                 
int("1.0")  # ValueError ✗
int(float("1.0"))  # 1 ✓
```

2. Build streamlit app in `streamlit_app/app.py`

**Manual Verification**
install dependencies:
```
uv sync --extra test --extra examples --extra streamlit
```

run streamlit app:
```
PYTHONPATH=. uv run streamlit run streamlit_app/app.py
```

upload a csv dataset and run model. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web UI for labeling: CSV upload, dataset validation, model selection, start button, live progress, result preview, download, and background run orchestration with final status.

* **Chores**
  * Added optional Streamlit dependency and ignored Streamlit runtime upload/output folders.

* **Quality**
  * Improved column-name handling and CSV validation, safer gold-label parsing, progress reporting during evaluation, and enhanced tests for multi-batch dataloaders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->